### PR TITLE
implement COW on ghost memory

### DIFF
--- a/SVA/include/sva/mmu.h
+++ b/SVA/include/sva/mmu.h
@@ -255,6 +255,10 @@ static page_desc_t page_desc[numPageDescEntries];
 #define NBPML4      (1UL<<PML4SHIFT)/* bytes/page map lev4 table */
 #define PML4MASK    (NBPML4-1)
 
+/* Page fault code flags*/
+#define PGEX_P      0x01    /* Protection violation vs. not present */
+#define PGEX_W      0x02    /* during a Write cycle */
+
 /*
  * ===========================================================================
  * END FreeBSD CODE BLOCK
@@ -461,6 +465,67 @@ setMappingReadWrite (page_entry_t mapping) {
   return (mapping | PG_RW); 
 }
 
+static inline pml4e_t *
+get_pml4eVaddr (unsigned char * cr3, uintptr_t vaddr) {
+  /* Offset into the page table */
+  uintptr_t offset = (vaddr >> (39 - 3)) & vmask;
+  return (pml4e_t *) getVirtual (((uintptr_t)cr3) | offset);
+}
+
+static inline pdpte_t *
+get_pdpteVaddr (pml4e_t * pml4e, uintptr_t vaddr) {
+  uintptr_t base   = (*pml4e) & 0x000ffffffffff000u;
+  uintptr_t offset = (vaddr >> (30 - 3)) & vmask;
+  return (pdpte_t *) getVirtual (base | offset);
+}
+
+static inline pde_t *
+get_pdeVaddr (pdpte_t * pdpte, uintptr_t vaddr) {
+  uintptr_t base   = (*pdpte) & 0x000ffffffffff000u;
+  uintptr_t offset = (vaddr >> (21 - 3)) & vmask;
+  return (pde_t *) getVirtual (base | offset);
+}
+
+static inline pte_t *
+get_pteVaddr (pde_t * pde, uintptr_t vaddr) {
+  uintptr_t base   = (*pde) & 0x000ffffffffff000u;
+  uintptr_t offset = (vaddr >> (12 - 3)) & vmask;
+  return (pte_t *) getVirtual (base | offset);
+}
+
+/*
+ * Functions for returing the physical address of page table pages.
+ */
+static inline uintptr_t
+get_pml4ePaddr (unsigned char * cr3, uintptr_t vaddr) {
+  /* Offset into the page table */
+  uintptr_t offset = ((vaddr >> 39) << 3) & vmask;
+  return (((uintptr_t)cr3) | offset);
+}
+
+static inline uintptr_t
+get_pdptePaddr (pml4e_t * pml4e, uintptr_t vaddr) {
+  uintptr_t offset = ((vaddr  >> 30) << 3) & vmask;
+  return ((*pml4e & 0x000ffffffffff000u) | offset);
+}
+
+static inline uintptr_t
+get_pdePaddr (pdpte_t * pdpte, uintptr_t vaddr) {
+  uintptr_t offset = ((vaddr  >> 21) << 3) & vmask;
+  return ((*pdpte & 0x000ffffffffff000u) | offset);
+}
+
+static inline uintptr_t
+get_ptePaddr (pde_t * pde, uintptr_t vaddr) {
+  uintptr_t offset = ((vaddr >> 12) << 3) & vmask;
+  return ((*pde & 0x000ffffffffff000u) | offset);
+}
+
+/* Functions for querying information about a page table entry */
+static inline unsigned char
+isPresent (uintptr_t * pte) {
+  return (*pte & 0x1u) ? 1u : 0u;
+}
 
 /*
  *****************************************************************************

--- a/SVA/include/sva/mmu.h
+++ b/SVA/include/sva/mmu.h
@@ -259,6 +259,10 @@ static page_desc_t page_desc[numPageDescEntries];
 #define PGEX_P      0x01    /* Protection violation vs. not present */
 #define PGEX_W      0x02    /* during a Write cycle */
 
+/* Fork code flags */
+#define RFPROC      (1<<4)  /* change child (else changes curproc) */
+#define RFMEM       (1<<5)  /* share `address space' */
+
 /*
  * ===========================================================================
  * END FreeBSD CODE BLOCK

--- a/SVA/include/sva/mmu_intrinsics.h
+++ b/SVA/include/sva/mmu_intrinsics.h
@@ -59,6 +59,7 @@
 #define SVA_MMU_INTRINSICS_H
 
 #include "mmu_types.h"
+#include "state.h"
 
 /*
  *****************************************************************************
@@ -85,6 +86,9 @@ extern void sva_mmu_init(pml4e_t * kpml4Mapping,
 
 /* Key initialization and secure storage allocation */
 extern void * sva_translate(void * entryPoint);
+
+/* COW on ghost memory at fork */
+extern void ghostmemCOW(struct SVAThread* oldThread, struct SVAThread* newThread);
 
 /*
  *****************************************************************************

--- a/SVA/include/sva/state.h
+++ b/SVA/include/sva/state.h
@@ -278,8 +278,6 @@ struct SVAThread {
   /* Randomly created identifier */
   uintptr_t rid;
   
-  /* Save necessary flags of system calls */
-  unsigned int flags;
 } __attribute__ ((aligned (16)));
 
 /*

--- a/SVA/include/sva/state.h
+++ b/SVA/include/sva/state.h
@@ -277,6 +277,9 @@ struct SVAThread {
 
   /* Randomly created identifier */
   uintptr_t rid;
+  
+  /* Save necessary flags of system calls */
+  unsigned int flags;
 } __attribute__ ((aligned (16)));
 
 /*
@@ -410,6 +413,7 @@ sva_invokestrncpy (char * dst, const char * src, uintptr_t count);
 extern uintptr_t sva_swap_integer  (uintptr_t new, uintptr_t * state);
 extern uintptr_t sva_init_stack (unsigned char * sp,
                                  uintptr_t length,
+				 uintptr_t cr3,
                                  void * f,
                                  uintptr_t arg1,
                                  uintptr_t arg2,

--- a/SVA/lib/handlers.S
+++ b/SVA/lib/handlers.S
@@ -507,24 +507,58 @@ SVAsyscall:
    * if this is the fork(), vfork(), rfork(), or pdfork() system calls.  The
    * system call number will be in %rax and can have the following values
    * (you can find these in syscalls.master) within the FreeBSD kernel source
-   * code):
+   * code).
+   * According to the type of fork and the flags, we make a decision about
+   * whether to COW on ghost memory or not, and save the decision in the flags
+   * filed of the current SVAThread. (1 is COW, and 0 is not COW.)
+   * In particular, fork() and pdfork() always incur COW, vfork() does not incur COW,
+   * and for rfork() it depends on its arguments.
    *
    *   2 - fork()
    *  66 - vfork()
    * 251 - rfork()
    * 518 - pdfork()
    */
+
+  /* Find the flags field of the current SVAThread */
+  movq %gs:0x260, %r14          
+  movq CPU_THREAD(%r14), %r14    
+  movq $0,  0x7d80(%r14)  
+  movq $0, %rbx
+  movq $1, %r11
+
   movq $1, %r12
   movq $3, %r13
   cmpq $2, IC_RAX(%rsp)
   cmoveq %r13, %r12
+  cmoveq %r11, %rbx
+  je DONE_FORK
+
   cmpq $66, IC_RAX(%rsp)
   cmoveq %r13, %r12
+  je DONE_FORK
+
   cmpq $251, IC_RAX(%rsp)
-  cmoveq %r13, %r12
+  jne NEXT_TEST_FORK
+  movq %r13, %r12
+  /* test the syscall argument flags, whether 
+   * (flags & RFPROC) && !(flags & RFMEM) is true. 
+   * If it is true, we need COW on ghost memory.
+   */
+  movq (%rdi), %r15
+  andq $48, %r15   
+  cmpq $16, %r15
+  cmoveq %r11, %rbx
+  jmp DONE_FORK  
+
+NEXT_TEST_FORK:
   cmpq $518, IC_RAX(%rsp)
   cmoveq %r13, %r12
+  cmoveq %r11, %rbx
+
+DONE_FORK: 
   movq %r12, IC_VALID(%rsp)
+  movq %rbx, 0x7d80(%r14)
 
   /*
    * Configure the process to trigger a floating point fault while in

--- a/SVA/lib/handlers.S
+++ b/SVA/lib/handlers.S
@@ -507,58 +507,24 @@ SVAsyscall:
    * if this is the fork(), vfork(), rfork(), or pdfork() system calls.  The
    * system call number will be in %rax and can have the following values
    * (you can find these in syscalls.master) within the FreeBSD kernel source
-   * code).
-   * According to the type of fork and the flags, we make a decision about
-   * whether to COW on ghost memory or not, and save the decision in the flags
-   * filed of the current SVAThread. (1 is COW, and 0 is not COW.)
-   * In particular, fork() and pdfork() always incur COW, vfork() does not incur COW,
-   * and for rfork() it depends on its arguments.
+   * code):
    *
    *   2 - fork()
    *  66 - vfork()
    * 251 - rfork()
    * 518 - pdfork()
    */
-
-  /* Find the flags field of the current SVAThread */
-  movq %gs:0x260, %r14          
-  movq CPU_THREAD(%r14), %r14    
-  movq $0,  0x7d80(%r14)  
-  movq $0, %rbx
-  movq $1, %r11
-
   movq $1, %r12
   movq $3, %r13
   cmpq $2, IC_RAX(%rsp)
   cmoveq %r13, %r12
-  cmoveq %r11, %rbx
-  je DONE_FORK
-
   cmpq $66, IC_RAX(%rsp)
   cmoveq %r13, %r12
-  je DONE_FORK
-
   cmpq $251, IC_RAX(%rsp)
-  jne NEXT_TEST_FORK
-  movq %r13, %r12
-  /* test the syscall argument flags, whether 
-   * (flags & RFPROC) && !(flags & RFMEM) is true. 
-   * If it is true, we need COW on ghost memory.
-   */
-  movq (%rdi), %r15
-  andq $48, %r15   
-  cmpq $16, %r15
-  cmoveq %r11, %rbx
-  jmp DONE_FORK  
-
-NEXT_TEST_FORK:
+  cmoveq %r13, %r12 
   cmpq $518, IC_RAX(%rsp)
   cmoveq %r13, %r12
-  cmoveq %r11, %rbx
-
-DONE_FORK: 
   movq %r12, IC_VALID(%rsp)
-  movq %rbx, 0x7d80(%r14)
 
   /*
    * Configure the process to trigger a floating point fault while in

--- a/SVA/lib/mmu.c
+++ b/SVA/lib/mmu.c
@@ -1341,16 +1341,16 @@ ghostmemCOW(struct SVAThread* oldThread, struct SVAThread* newThread)
    
     unprotect_paging(); 
     if (!isPresent (pml4e)) {
-    /* Page table page index */
-    unsigned int ptindex;
+      /* Page table page index */
+      unsigned int ptindex;
 
-    /* Fetch a new page table page */
-    ptindex = allocPTPage ();
-    /*
-     * Install a new PDPTE entry using the page.
-     */
-    uintptr_t paddr = PTPages[ptindex].paddr;
-    *pml4e = (paddr & addrmask) | PTE_CANWRITE | PTE_CANUSER | PTE_PRESENT;
+      /* Fetch a new page table page */
+      ptindex = allocPTPage ();
+      /*
+       * Install a new PDPTE entry using the page.
+       */
+      uintptr_t paddr = PTPages[ptindex].paddr;
+      *pml4e = (paddr & addrmask) | PTE_CANWRITE | PTE_CANUSER | PTE_PRESENT;
     }
     
     /*
@@ -1393,7 +1393,7 @@ ghostmemCOW(struct SVAThread* oldThread, struct SVAThread* newThread)
            updateUses (pdpte);
 
            if ((*pdpte) & PTE_PS) {
-              printf ("ghostmemCOW: PDPTE has PS BIT\n");
+             printf ("ghostmemCOW: PDPTE has PS BIT\n");
            }
 
            pde_t * src_pde = get_pdeVaddr (src_pdpte, vaddr_pdp);
@@ -1406,53 +1406,53 @@ ghostmemCOW(struct SVAThread* oldThread, struct SVAThread* newThread)
            pde ++) 
            {
 
-                 /*
-                  * Get the PDE entry (or add it if it is not present).
-                  */
-                  if(!isPresent (src_pde))
-		           continue;
+             /*
+              * Get the PDE entry (or add it if it is not present).
+              */
+              if(!isPresent (src_pde))
+	        continue;
 		  
-		  if (!isPresent (pde)) {
-                  /* Page table page index */
-     	                   unsigned int ptindex;
+	      if (!isPresent (pde)) {
+                /* Page table page index */
+     	        unsigned int ptindex;
 
-                  /* Fetch a new page table page */
-	                   ptindex = allocPTPage ();
+                /* Fetch a new page table page */
+	        ptindex = allocPTPage ();
 
-                 /*
-                  * Install a new PDE entry.
-                  */
-                  uintptr_t pde_paddr = PTPages[ptindex].paddr;
-                  *pde = (pde_paddr & addrmask) | PTE_CANWRITE | PTE_CANUSER | PTE_PRESENT;
-           	  }
-           	  *pde |= PTE_CANUSER;
+                /*
+                 * Install a new PDE entry.
+                 */
+                uintptr_t pde_paddr = PTPages[ptindex].paddr;
+                *pde = (pde_paddr & addrmask) | PTE_CANWRITE | PTE_CANUSER | PTE_PRESENT;
+               }
+               *pde |= PTE_CANUSER;
 
-          	 /*
-          	  * Note that we've added another translation to the pdpte.
-           	  */
-           	  updateUses (pde);
+               /*
+          	* Note that we've added another translation to the pdpte.
+           	*/
+               updateUses (pde);
 
-           	if ((*pde) & PTE_PS) {
-                 	 printf ("ghostmemCOW: PDE has PS BIT\n");
-           	}
+               if ((*pde) & PTE_PS) {
+                 printf ("ghostmemCOW: PDE has PS BIT\n");
+               }
        
        
-           	pte_t * src_pte = get_pteVaddr (src_pde, vaddr_pde);
-           	pte_t * pte = get_pteVaddr (pde, vaddr_pde);	
+               pte_t * src_pte = get_pteVaddr (src_pde, vaddr_pde);
+               pte_t * pte = get_pteVaddr (pde, vaddr_pde);	
 
-           	for(uintptr_t vaddr_pte = vaddr_pde;
-           	vaddr_pte < vaddr_pde + NBPDR; 
-           	vaddr_pte += PAGE_SIZE,\
-           	src_pte ++,\
-           	pte ++)
-           	{
-               	  if(!isPresent (src_pte))
-			continue;
+               for(uintptr_t vaddr_pte = vaddr_pde;
+               vaddr_pte < vaddr_pde + NBPDR; 
+               vaddr_pte += PAGE_SIZE,\
+               src_pte ++,\
+               pte ++)
+               {
+                  if(!isPresent (src_pte))
+	            continue;
 
 	       	  page_desc_t * pgDesc = getPageDescPtr (*src_pte & PG_FRAME);
 		  
 		  if(pgDesc->type != PG_GHOST)
-                  	panic("ghostmemCOW: page is not a ghost memory page! vaddr = 0x%lx, src_pte = 0x%lx, *src_pte = 0x%lx, src_pde = 0x%lx, *src_pde = 0x%lx\n", vaddr_pte, src_pte, *src_pte, src_pde, *src_pde);
+                    panic("ghostmemCOW: page is not a ghost memory page! vaddr = 0x%lx, src_pte = 0x%lx, *src_pte = 0x%lx, src_pde = 0x%lx, *src_pde = 0x%lx\n", vaddr_pte, src_pte, *src_pte, src_pde, *src_pde);
 
                	  *src_pte &= ~PTE_CANWRITE; 
                   *pte = *src_pte;

--- a/SVA/lib/secmem.c
+++ b/SVA/lib/secmem.c
@@ -502,6 +502,17 @@ freeSecureMemory (void) {
   return;
 }
 
+/*
+ * Function: sva_ghost_fault()
+ *
+ * Description:
+ *  Handle page faults of ghost memory pages.
+ *
+ * Inputs:
+ *  vaddr - The virtual address of the faulting ghost memory page.
+ *  code  - The page fault code.
+ *
+ */
 void
 sva_ghost_fault (uintptr_t vaddr, unsigned long code) {
   /* Old interrupt flags */
@@ -553,7 +564,7 @@ sva_ghost_fault (uintptr_t vaddr, unsigned long code) {
      else
      {
         uintptr_t vaddr_old = (uintptr_t) getVirtual(paddr);
-        uintptr_t paddr_new = provideSVAMemory (X86_PAGE_SIZE);
+        uintptr_t paddr_new = alloc_frame (X86_PAGE_SIZE);
         page_desc_t * pgDesc_new = getPageDescPtr (paddr_new);
         if (pgRefCount (pgDesc_new) > 1) {
                 panic ("SVA: Ghost page still in use somewhere else!\n");

--- a/SVA/lib/secmem.c
+++ b/SVA/lib/secmem.c
@@ -462,7 +462,8 @@ ghostFree (struct SVAThread * threadp, unsigned char * p, intptr_t size) {
          *  implementation in which it only releases one page at a time to the
          *  OS.
          */
-        free_frame(paddr);
+	if(getPageDescPtr(paddr)->count == 0)
+        	free_frame(paddr);
       }
     }
   }
@@ -502,7 +503,7 @@ freeSecureMemory (void) {
 }
 
 void
-sva_ghost_fault (uintptr_t vaddr) {
+sva_ghost_fault (uintptr_t vaddr, unsigned long code) {
   /* Old interrupt flags */
   uintptr_t rflags;
 
@@ -522,6 +523,58 @@ sva_ghost_fault (uintptr_t vaddr) {
    */
   struct CPUState * cpup = getCPUState();
   struct SVAThread * threadp = cpup->currentThread;
+
+  /* copy-on-write page fault */
+  if((code & PGEX_P) && (code & PGEX_W)){
+     pml4e_t * pml4e_ptr = get_pml4eVaddr (get_pagetable(), vaddr);
+     if(!isPresent (pml4e_ptr)) 
+        panic("sva_ghost_fault: cow pgfault pml4e %p does not exist\n", pml4e);
+     pdpte_t * pdpte = get_pdpteVaddr (pml4e_ptr, vaddr);
+     if(!isPresent (pdpte)) 
+        panic("sva_ghost_fault: cow pgfault pdpte %p does not exist\n", pdpte);
+     pde_t * pde = get_pdeVaddr (pdpte, vaddr);
+     if(!isPresent (pde)) 
+        panic("sva_ghost_fault: cow pgfault pde %p does not exist\n", pde);
+     pte_t * pte = get_pteVaddr (pde, vaddr);
+     uintptr_t paddr = *pte & PG_FRAME;
+     page_desc_t * pgDesc = getPageDescPtr (paddr);
+
+     if(pgDesc->type != PG_GHOST)
+	panic("SVA: sva_ghost_fault: vaddr = 0x%lx paddr = 0x%lx is not a ghost memory page!\n", vaddr, paddr); 
+     /* If only one process maps this page, directly grant this process write permission */
+
+
+     unprotect_paging();
+     if(pgDesc->count == 1)
+     {
+        * pte = (* pte) | PTE_CANWRITE;
+     }
+     /* Otherwise copy-on-write */
+     else
+     {
+        uintptr_t vaddr_old = (uintptr_t) getVirtual(paddr);
+        uintptr_t paddr_new = provideSVAMemory (X86_PAGE_SIZE);
+        page_desc_t * pgDesc_new = getPageDescPtr (paddr_new);
+        if (pgRefCount (pgDesc_new) > 1) {
+                panic ("SVA: Ghost page still in use somewhere else!\n");
+        }
+        if (isPTP(pgDesc_new) || isCodePG (pgDesc_new)) {
+                panic ("SVA: Ghost page has wrong type!\n");
+        }
+        	
+        *pte = (paddr_new & addrmask) | PTE_CANWRITE | PTE_CANUSER | PTE_PRESENT;
+     	memcpy((void *)vaddr, (void *) vaddr_old, X86_PAGE_SIZE);   
+       
+       
+        getPageDescPtr (paddr_new)->type = PG_GHOST;
+        getPageDescPtr (paddr_new)->count = 1;
+        pgDesc->count --;
+     }
+     
+     protect_paging();
+
+     return; 
+   }
 
   /*
    * Determine if this is the first secure memory allocation.

--- a/SVA/lib/secmem.c
+++ b/SVA/lib/secmem.c
@@ -439,13 +439,6 @@ ghostFree (struct SVAThread * threadp, unsigned char * p, intptr_t size) {
        */
       uintptr_t paddr;
       if (getPhysicalAddrFromPML4E (ptr, secmemPML4Ep, &paddr)) {
-        /*
-         * Zero out the contents of the ghost memory if it has been mapped
-         * in the current address space.
-         */
-        if (threadp == currentThread) {
-          memset (ptr, 0, X86_PAGE_SIZE);
-        }
 
         /*
          * Unmap the memory from the secure memory virtual address space.
@@ -462,8 +455,16 @@ ghostFree (struct SVAThread * threadp, unsigned char * p, intptr_t size) {
          *  implementation in which it only releases one page at a time to the
          *  OS.
          */
-	if(getPageDescPtr(paddr)->count == 0)
-        	free_frame(paddr);
+	if(getPageDescPtr(paddr)->count == 0) {
+
+      	  /*
+           * Zero out the contents of the ghost memory if it has been mapped
+           * in the current address space.
+           */
+          memset (ptr, 0, X86_PAGE_SIZE);
+          
+	  free_frame(paddr);
+	}
       }
     }
   }

--- a/SVA/lib/secmem.c
+++ b/SVA/lib/secmem.c
@@ -461,7 +461,8 @@ ghostFree (struct SVAThread * threadp, unsigned char * p, intptr_t size) {
            * Zero out the contents of the ghost memory if it has been mapped
            * in the current address space.
            */
-          memset (ptr, 0, X86_PAGE_SIZE);
+	  if(threadp == currentThread)
+            memset (ptr, 0, X86_PAGE_SIZE);
           
 	  free_frame(paddr);
 	}

--- a/SVA/lib/state.c
+++ b/SVA/lib/state.c
@@ -1072,7 +1072,6 @@ sva_release_stack (uintptr_t id) {
  * Inputs:
  *  start_stackp    - A pointer to the *beginning* of the kernel stack.
  *  length          - Length of the kernel stack in bytes.
- *  is_fork         - Whether the parent forks a new process or just clones a new thread
  *  new_cr3	    - The new process(thread)'s cr3
  *  func            - The kernel function to execute when the new integer state
  *                    is swapped on to the processor.


### PR DESCRIPTION
1. ghostmemCOW(): Invoked at fork. It copies the page table entries of ghost memory from the parent to the child. Also, it write-protects these page table entries.
2. Modify sva_ghost_fault() to check whether the page fault is due to a write access to a read-only ghost memory page. If yes, COW that ghost memory page.
3. Create a new field called flags in SVAThread to save the decision regarding whether to do COW on ghost memory or not at fork. The decision is made based on the arguments of the fork family syscalls, which are extracted in SVASyscall handler.
4. Pull out previous inline functions such as get_pml4eVaddr() from SVA/lib/mmu.c to SVA/include/sva/mmu.h so that they could be called in other files such as SVA/lib/secmem.c