### PR TITLE
bug fix for issue 22- jump to invalid instruction

### DIFF
--- a/SVA/lib/thread_stack.c
+++ b/SVA/lib/thread_stack.c
@@ -114,8 +114,8 @@ init_threads(void) {
 static inline uintptr_t
 randomNumber (void) {
   uintptr_t rand;
-  __asm__ __volatile__ ("1: rdrand %0\n"
-                        "jae 1\n" : "=r" (rand));
+  __asm__ __volatile__ ("h: rdrand %0\n"
+                        "jae h\n" : "=r" (rand));
   return rand;
 }
 

--- a/SVA/lib/thread_stack.c
+++ b/SVA/lib/thread_stack.c
@@ -114,8 +114,8 @@ init_threads(void) {
 static inline uintptr_t
 randomNumber (void) {
   uintptr_t rand;
-  __asm__ __volatile__ ("h: rdrand %0\n"
-                        "jae h\n" : "=r" (rand));
+  __asm__ __volatile__ ("1: rdrand %0\n"
+                        "jae 1b\n" : "=r" (rand));
   return rand;
 }
 


### PR DESCRIPTION
This fix addresses the issue, the jump does not happen to mid of instruction set with this fix, but happens to loop back to rdrand.