### PR TITLE
Fixed random number generator.

### DIFF
--- a/SVA/include/sva/util.h
+++ b/SVA/include/sva/util.h
@@ -110,6 +110,21 @@ bochsBreak (void) {
   return;
 }
 
+/*
+ * Function: sva_random()
+ *
+ * Description:
+ *  Random number generator in SVA. Current implementation uses the rdrand
+ *  instruction to generate a 64-bit random number.
+ */
+static inline unsigned long
+sva_random(void) {
+  unsigned long rand;
+  __asm__ __volatile__ ("1: rdrand %0\n"
+			"jae 1b\n" : "=r" (rand));
+  return rand;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/SVA/lib/secmem.c
+++ b/SVA/lib/secmem.c
@@ -31,8 +31,6 @@
  */
 #define MAX_FRAMES_PER_OP 32
 
-extern u_long random(void);
-
 /* Frame cache queue */
 static uintptr_t frame_cache[FRAME_CACHE_SIZE];
 
@@ -146,7 +144,7 @@ fill_in_frames(void) {
   max_nframe = FRAME_CACHE_SIZE - 1 - frame_cache_used();
   if (vg_random) {
     /* A random number between 1 and current capacity of frame cache queue */
-    nframe = random() % max_nframe + 1;
+    nframe = sva_random() % max_nframe + 1;
   } else {
     /* Minimum of a constant and current capacity of frame cache queue */
     nframe = max_nframe < MAX_FRAMES_PER_OP ? max_nframe : MAX_FRAMES_PER_OP;
@@ -176,7 +174,7 @@ release_frames(void) {
   max_nframe = frame_cache_used();
   if (vg_random) {
     /* A random number between 1 and current occupancy of frame cache queue */
-    nframe = random() % max_nframe + 1;
+    nframe = sva_random() % max_nframe + 1;
   } else {
     /* Minimum of a constant and current occupancy of frame cache queue */
     nframe = max_nframe < MAX_FRAMES_PER_OP ? max_nframe : MAX_FRAMES_PER_OP;

--- a/SVA/lib/thread_stack.c
+++ b/SVA/lib/thread_stack.c
@@ -14,6 +14,7 @@
 
 #include "sva/config.h"
 #include "sva/callbacks.h"
+#include "sva/util.h"
 #include "keys.h"
 #include "thread_stack.h"
 
@@ -103,20 +104,6 @@ static inline struct SVAThread *ftstack_pop(void) {
 void
 init_threads(void) {
   return;
-}
-
-/*
- * Function: randomNumber()
- *
- * Description:
- *  Use the rdrand instruction to generate a 64-bit random number.
- */
-static inline uintptr_t
-randomNumber (void) {
-  uintptr_t rand;
-  __asm__ __volatile__ ("1: rdrand %0\n"
-                        "jae 1b\n" : "=r" (rand));
-  return rand;
 }
 
 /*
@@ -217,7 +204,7 @@ findNextFreeThread (void) {
      * Generate a random identifier for the new thread.
      */
     if (vg) {
-      newThread->rid = randomNumber();
+      newThread->rid = sva_random();
     }
     return newThread;
   }


### PR DESCRIPTION
In this pull request,

- Function `randomNumber()` in `lib/thread_stack.c` is renamed to `sva_random()` and moved to `sva/util.h` so that other `.c` files can use it to generate random numbers.
- Random number generator used in `lib/secmem.c` is switched from OS callback `random()` to `sva_random()`, keeping consistency with `lib/thread_stack.c`.