### PR TITLE
TLS support, both single/multi- user mode; TLS managed by FreeBSD Kernel

### DIFF
--- a/SVA/include/sva/state.h
+++ b/SVA/include/sva/state.h
@@ -23,6 +23,21 @@
 #include "sva/keys.h"
 
 
+// // from sys/amd64/include/specialreg.h
+#ifndef MSR_FSBASE
+#define	MSR_FSBASE	0xc0000100	/* base address of the %fs "segment" */
+#endif
+
+#ifndef MSR_GSBASE
+#define	MSR_GSBASE	0xc0000101	/* base address of the %gs "segment" */
+#endif 
+
+#ifndef MSR_KGSBASE
+#define	MSR_KGSBASE	0xc0000102	/* base address of the kernel %gs */
+#endif
+
+
+
 extern void usersva_to_kernel_pcid(void);
 extern void kernel_to_usersva_pcid(void);
 

--- a/SVA/lib/handlers.S
+++ b/SVA/lib/handlers.S
@@ -579,7 +579,7 @@ L14:
   movw IC_FS(%rsp), %ax
   movw IC_ES(%rsp), %bx
   movw IC_DS(%rsp), %cx
-  movw %ax, %fs
+  /* movw %ax, %fs */ /* Lele: don't set fs register here, use hypercall to SVA*/
   movw %bx, %es
   movw %cx, %ds
 
@@ -1021,7 +1021,7 @@ L18:
   movw IC_FS(%rsp), %cx
   movw IC_ES(%rsp), %bx
   movw IC_DS(%rsp), %ax
-  movw %cx, %fs
+  /*movw %cx, %fs  *//* this already done in sva_syscall*/
   movw %bx, %es
   movw %ax, %ds
 

--- a/SVA/lib/offsets.h
+++ b/SVA/lib/offsets.h
@@ -78,3 +78,10 @@
 #define INVOKE_MEMSET   2
 
 
+/* segment registers for TLS support
+ * refer: sys/amd64/include/specialreg.h
+*/
+#define	MSR_FSBASE	0xc0000100	/* base address of the %fs "segment" */
+#define	MSR_GSBASE	0xc0000101	/* base address of the %gs "segment" */
+#define	MSR_KGSBASE	0xc0000102	/* base address of the kernel %gs */
+

--- a/freebsd9_patch
+++ b/freebsd9_patch
@@ -3524,6 +3524,259 @@ index 2f737758..27b571c2 100644
  	movl	$EFAULT,%eax
 -	ret
 +	RETQ
+diff --git a/sys/amd64/amd64/sva_support.c b/sys/amd64/amd64/sva_support.c
+new file mode 100644
+index 00000000..ed8ff1dc
+--- /dev/null
++++ b/sys/amd64/amd64/sva_support.c
+@@ -0,0 +1,247 @@
++#include <sys/cdefs.h>
++#include <sys/param.h>
++#include <sys/systm.h>
++#include <sys/pcpu.h>
++
++#include <vm/vm.h>
++#include <vm/pmap.h>
++
++#include <machine/vmparam.h>
++#include <machine/pcb.h>
++
++/*
++ * Prototypes for the real functions.
++ */
++extern int real_copyin(const void * __restrict udaddr, void * __restrict kaddr, size_t len) __nonnull(1) __nonnull(2);
++
++extern int real_copyout(const void * __restrict kaddr, void * __restrict udaddr, size_t len) __nonnull(1) __nonnull(2);
++
++extern long	real_fuword(const void *base);
++extern int	real_fubyte(const void *base);
++extern int	real_fuword16(void *base);
++extern int32_t	real_fuword32(const void *base);
++extern int64_t	real_fuword64(const void *base);
++
++extern int real_subyte(void *base, int byte);
++extern int real_suword(void *base, long word);
++extern int real_suword16(void *base, int word);
++extern int real_suword32(void *base, int32_t word);
++extern int real_suword64(void *base, int64_t word);
++
++extern uint32_t real_casuword32(volatile uint32_t *base, uint32_t oldval, uint32_t newval);
++extern u_long	 real_casuword(volatile u_long *p, u_long oldval, u_long newval);
++
++/*
++ * Implementations of the functions that use the SVA-OS intrinsics.
++ */
++int
++copyinstr(const void * __restrict udaddr, void * __restrict kaddr,
++	        size_t len, size_t * __restrict lencopied) {
++  /* Number of bytes copied */
++  uintptr_t copySize;
++
++  /*
++   * Ensure that the copy won't read in kernel-space memory for the string.
++   */
++  if (VM_MAXUSER_ADDRESS <= udaddr)
++    return EFAULT;
++
++  if (len >= (VM_MAXUSER_ADDRESS - (uintptr_t)udaddr))
++    len = (VM_MAXUSER_ADDRESS - (uintptr_t)udaddr);
++
++  /*
++   * Note that we want to use SVA to unwind the stack if we hit a fault.
++   */
++  PCPU_GET(curpcb)->pcb_onfault = 1;
++
++  /*
++   * Perform the copy.
++   */
++  copySize = sva_invokestrncpy (kaddr, udaddr, len);
++
++  /*
++   * Note that we aren't expecting a fault now.
++   */
++  PCPU_GET(curpcb)->pcb_onfault = 0;
++
++  /*
++   * Determine if the string name is too long or if we hit a fault.
++   */
++  if (copySize == -1)
++    return EFAULT;
++
++  if (copySize == len)
++    return ENAMETOOLONG;
++
++  /*
++   * Report the number of bytes copied to the caller.
++   */
++  if (lencopied)
++    *lencopied = copySize + 1;
++  return 0;
++}
++
++int
++copyin(const void * __restrict udaddr,
++       void * __restrict kaddr,
++	    size_t len) {
++  uintptr_t retval;
++  if (sva_invoke (udaddr, kaddr, len, &retval, real_copyin)) {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return EFAULT;
++  } else {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return (int)(retval);
++  }
++}
++
++int
++copyout(const void * __restrict kaddr,
++        void * __restrict udaddr,
++        size_t len) {
++  uintptr_t retval;
++  if (sva_invoke (kaddr, udaddr, len, &retval, real_copyout)) {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return EFAULT;
++  } else {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return (int)(retval);
++  }
++}
++
++int64_t
++fuword64 (const void * addr) {
++  uintptr_t retval;
++  if (sva_invoke (addr, 0, 0, &retval, real_fuword64)) {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return -1;
++  } else {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return (int64_t)(retval);
++  }
++}
++
++int64_t
++fuword (const void * addr) {
++  return fuword64 (addr);
++}
++
++int32_t
++fuword32 (const void * addr) {
++  uintptr_t retval;
++  if (sva_invoke (addr, 0, 0, &retval, real_fuword32)) {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return -1;
++  } else {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return (int32_t)(retval);
++  }
++}
++
++int
++fuword16 (void * addr) {
++  uintptr_t retval;
++  if (sva_invoke (addr, 0, 0, &retval, real_fuword16)) {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return -1;
++  } else {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return (int)(retval);
++  }
++}
++
++int
++fubyte (const void * addr) {
++  uintptr_t retval;
++  if (sva_invoke (addr, 0, 0, &retval, real_fubyte)) {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return -1;
++  } else {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return (int)(retval);
++  }
++}
++
++int
++subyte(void *base, int byte) {
++  uintptr_t retval;
++  if (sva_invoke (base, byte, 0, &retval, real_subyte)) {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return -1;
++  } else {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return (int)(retval);
++  }
++}
++
++int
++suword(void *base, long word) {
++  uintptr_t retval;
++  if (sva_invoke (base, word, 0, &retval, real_suword)) {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return -1;
++  } else {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return (int)(retval);
++  }
++}
++
++int
++suword16(void *base, int word) {
++  uintptr_t retval;
++  if (sva_invoke (base, word, 0, &retval, real_suword16)) {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return -1;
++  } else {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return (int)(retval);
++  }
++}
++
++int
++suword32(void *base, int32_t word) {
++  uintptr_t retval;
++  if (sva_invoke (base, word, 0, &retval, real_suword32)) {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return -1;
++  } else {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return (int)(retval);
++  }
++}
++
++int
++suword64(void *base, int64_t word) {
++  uintptr_t retval;
++  if (sva_invoke (base, word, 0, &retval, real_suword64)) {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return -1;
++  } else {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return (int)(retval);
++  }
++}
++
++uint32_t
++casuword32 (volatile uint32_t *base, uint32_t oldval, uint32_t newval) {
++  uintptr_t retval;
++  if (sva_invoke (base, oldval, newval, &retval, real_casuword32)) {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return -1;
++  } else {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return (int)(retval);
++  }
++}
++
++u_long
++casuword(volatile u_long *p, u_long oldval, u_long newval) {
++  uintptr_t retval;
++  if (sva_invoke (p, oldval, newval, &retval, real_casuword)) {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return -1;
++  } else {
++    PCPU_GET(curpcb)->pcb_onfault = 0;
++    return (int)(retval);
++  }
++}
 diff --git a/sys/amd64/amd64/sys_machdep.c b/sys/amd64/amd64/sys_machdep.c
 index 743a1200..519f6ec5 100644
 --- a/sys/amd64/amd64/sys_machdep.c
@@ -4933,6 +5186,712 @@ index c0be7202..d844c736 100644
  
  /*
   * Set that machine state for performing an upcall that has to
+diff --git a/sys/amd64/conf/SVA b/sys/amd64/conf/SVA
+new file mode 100644
+index 00000000..aeb23998
+--- /dev/null
++++ b/sys/amd64/conf/SVA
+@@ -0,0 +1,352 @@
++#
++# GENERIC -- Generic kernel configuration file for FreeBSD/amd64
++#
++# For more information on this file, please read the config(5) manual page,
++# and/or the handbook section on Kernel Configuration Files:
++#
++#    http://www.FreeBSD.org/doc/en_US.ISO8859-1/books/handbook/kernelconfig-config.html
++#
++# The handbook is also available locally in /usr/share/doc/handbook
++# if you've installed the doc distribution, otherwise always see the
++# FreeBSD World Wide Web server (http://www.FreeBSD.org/) for the
++# latest information.
++#
++# An exhaustive list of options and more detailed explanations of the
++# device lines is also present in the ../../conf/NOTES and NOTES files.
++# If you are in doubt as to the purpose or necessity of a line, check first
++# in NOTES.
++#
++# $FreeBSD: release/9.0.0/sys/amd64/conf/GENERIC 227305 2011-11-07 13:40:54Z marius $
++
++cpu		HAMMER
++ident		GENERIC
++
++#makeoptions	DEBUG=-g		# Build kernel with gdb(1) debug symbols
++
++#******************
++# SVA Related Flags
++#******************
++options     SVA_MMU
++
++options 	SCHED_ULE		# ULE scheduler
++#options   SCHED_4BSD
++options 	PREEMPTION		# Enable kernel thread preemption
++options 	INET			# InterNETworking
++options 	INET6			# IPv6 communications protocols
++options 	SCTP			# Stream Control Transmission Protocol
++options 	FFS			# Berkeley Fast Filesystem
++options 	SOFTUPDATES		# Enable FFS soft updates support
++options 	UFS_ACL			# Support for access control lists
++options 	UFS_DIRHASH		# Improve performance on big directories
++options 	UFS_GJOURNAL		# Enable gjournal-based UFS journaling
++options 	MD_ROOT			# MD is a potential root device
++options 	NFSCL			# New Network Filesystem Client
++options 	NFSD			# New Network Filesystem Server
++options 	NFSLOCKD		# Network Lock Manager
++options 	NFS_ROOT		# NFS usable as /, requires NFSCL
++options 	MSDOSFS			# MSDOS Filesystem
++options 	CD9660			# ISO 9660 Filesystem
++options 	PROCFS			# Process filesystem (requires PSEUDOFS)
++options 	PSEUDOFS		# Pseudo-filesystem framework
++options 	GEOM_PART_GPT		# GUID Partition Tables.
++options 	GEOM_LABEL		# Provides labelization
++options 	COMPAT_FREEBSD32	# Compatible with i386 binaries
++options 	COMPAT_FREEBSD4		# Compatible with FreeBSD4
++options 	COMPAT_FREEBSD5		# Compatible with FreeBSD5
++options 	COMPAT_FREEBSD6		# Compatible with FreeBSD6
++options 	COMPAT_FREEBSD7		# Compatible with FreeBSD7
++options 	SCSI_DELAY=5000		# Delay (in ms) before probing SCSI
++options 	KTRACE			# ktrace(1) support
++options 	STACK			# stack(9) support
++options 	SYSVSHM			# SYSV-style shared memory
++options 	SYSVMSG			# SYSV-style message queues
++options 	SYSVSEM			# SYSV-style semaphores
++options 	_KPOSIX_PRIORITY_SCHEDULING # POSIX P1003_1B real-time extensions
++options 	PRINTF_BUFR_SIZE=128	# Prevent printf output being interspersed.
++options 	KBD_INSTALL_CDEV	# install a CDEV entry in /dev
++options 	HWPMC_HOOKS		# Necessary kernel hooks for hwpmc(4)
++options 	AUDIT			# Security event auditing
++options 	MAC			# TrustedBSD MAC Framework
++#options 	KDTRACE_FRAME		# Ensure frames are compiled in
++#options 	KDTRACE_HOOKS		# Kernel DTrace hooks
++options 	INCLUDE_CONFIG_FILE     # Include this file in kernel
++options 	KDB			# Kernel debugger related code
++#options 	KDB_TRACE		# Print a stack trace for a panic
++options		DDB
++options		BREAK_TO_DEBUGGER # Break signal on console goes into debugger
++options		ALT_BREAK_TO_DEBUGGER # Break signal on console goes into debugger
++
++# JTC: lock debugging stuff
++#options WITNESS
++#options WITNESS_KDB
++#options WITNESS_SKIPSPIN
++
++# Make an SMP-capable kernel by default
++#options 	SMP			# Symmetric MultiProcessor Kernel
++
++# CPU frequency control
++#device		cpufreq
++
++# Bus support.
++device		acpi
++device		pci
++
++# Floppy drives
++device		fdc
++
++# ATA controllers
++device		ahci		# AHCI-compatible SATA controllers
++device		ata		# Legacy ATA/SATA controllers
++options 	ATA_CAM		# Handle legacy controllers with CAM
++options 	ATA_STATIC_ID	# Static device numbering
++device		mvs		# Marvell 88SX50XX/88SX60XX/88SX70XX/SoC SATA
++device		siis		# SiliconImage SiI3124/SiI3132/SiI3531 SATA
++
++# SCSI Controllers
++device		ahc		# AHA2940 and onboard AIC7xxx devices
++options 	AHC_REG_PRETTY_PRINT	# Print register bitfields in debug
++					# output.  Adds ~128k to driver.
++device		ahd		# AHA39320/29320 and onboard AIC79xx devices
++options 	AHD_REG_PRETTY_PRINT	# Print register bitfields in debug
++					# output.  Adds ~215k to driver.
++device		esp		# AMD Am53C974 (Tekram DC-390(T))
++device		hptiop		# Highpoint RocketRaid 3xxx series
++device		isp		# Qlogic family
++#device		ispfw		# Firmware for QLogic HBAs- normally a module
++device		mpt		# LSI-Logic MPT-Fusion
++device		mps		# LSI-Logic MPT-Fusion 2
++#device		ncr		# NCR/Symbios Logic
++device		sym		# NCR/Symbios Logic (newer chipsets + those of `ncr')
++device		trm		# Tekram DC395U/UW/F DC315U adapters
++
++device		adv		# Advansys SCSI adapters
++device		adw		# Advansys wide SCSI adapters
++device		aic		# Adaptec 15[012]x SCSI adapters, AIC-6[23]60.
++device		bt		# Buslogic/Mylex MultiMaster SCSI adapters
++
++# ATA/SCSI peripherals
++device		scbus		# SCSI bus (required for ATA/SCSI)
++device		ch		# SCSI media changers
++device		da		# Direct Access (disks)
++device		sa		# Sequential Access (tape etc)
++device		cd		# CD
++device		pass		# Passthrough device (direct ATA/SCSI access)
++device		ses		# SCSI Environmental Services (and SAF-TE)
++
++# RAID controllers interfaced to the SCSI subsystem
++#device		amr		# AMI MegaRAID
++#device		arcmsr		# Areca SATA II RAID
++#XXX it is not 64-bit clean, -scottl
++#device		asr		# DPT SmartRAID V, VI and Adaptec SCSI RAID
++#device		ciss		# Compaq Smart RAID 5*
++#device		dpt		# DPT Smartcache III, IV - See NOTES for options
++#device		hptmv		# Highpoint RocketRAID 182x
++#device		hptrr		# Highpoint RocketRAID 17xx, 22xx, 23xx, 25xx
++#device		iir		# Intel Integrated RAID
++#device		ips		# IBM (Adaptec) ServeRAID
++#device		mly		# Mylex AcceleRAID/eXtremeRAID
++#device		twa		# 3ware 9000 series PATA/SATA RAID
++
++# RAID controllers
++#device		aac		# Adaptec FSA RAID
++#device		aacp		# SCSI passthrough for aac (requires CAM)
++#device		ida		# Compaq Smart RAID
++#device		mfi		# LSI MegaRAID SAS
++#device		mlx		# Mylex DAC960 family
++#XXX pointer/int warnings
++#device		pst		# Promise Supertrak SX6000
++#device		twe		# 3ware ATA RAID
++#device		tws		# LSI 3ware 9750 SATA+SAS 6Gb/s RAID controller
++
++# atkbdc0 controls both the keyboard and the PS/2 mouse
++device		atkbdc		# AT keyboard controller
++device		atkbd		# AT keyboard
++device		psm		# PS/2 mouse
++
++device		kbdmux		# keyboard multiplexer
++
++device		vga		# VGA video card driver
++
++device		splash		# Splash screen and screen saver support
++
++# syscons is the default console driver, resembling an SCO console
++device		sc
++options 	SC_PIXEL_MODE	# add support for the raster text mode
++
++device		agp		# support several AGP chipsets
++
++# PCCARD (PCMCIA) support
++# PCMCIA and cardbus bridge support
++#device		cbb		# cardbus (yenta) bridge
++#device		pccard		# PC Card (16-bit) bus
++#device		cardbus		# CardBus (32-bit) bus
++
++# Serial (COM) ports
++device		uart		# Generic UART driver
++
++# Parallel port
++#device		ppc
++#device		ppbus		# Parallel port bus (required)
++#device		lpt		# Printer
++#device		plip		# TCP/IP over parallel
++#device		ppi		# Parallel port interface device
++#device		vpo		# Requires scbus and da
++
++device		puc		# Multi I/O cards and multi-channel UARTs
++
++# PCI Ethernet NICs.
++device		bxe		# Broadcom BCM57710/BCM57711/BCM57711E 10Gb Ethernet
++device		de		# DEC/Intel DC21x4x (``Tulip'')
++device		em		# Intel PRO/1000 Gigabit Ethernet Family
++device		igb		# Intel PRO/1000 PCIE Server Gigabit Family
++device		ixgbe		# Intel PRO/10GbE PCIE Ethernet Family
++device		le		# AMD Am7900 LANCE and Am79C9xx PCnet
++device		ti		# Alteon Networks Tigon I/II gigabit Ethernet
++device		txp		# 3Com 3cR990 (``Typhoon'')
++device		vx		# 3Com 3c590, 3c595 (``Vortex'')
++
++# PCI Ethernet NICs that use the common MII bus controller code.
++# NOTE: Be sure to keep the 'device miibus' line in order to use these NICs!
++#device		miibus		# MII bus support
++#device		ae		# Attansic/Atheros L2 FastEthernet
++#device		age		# Attansic/Atheros L1 Gigabit Ethernet
++#device		alc		# Atheros AR8131/AR8132 Ethernet
++#device		ale		# Atheros AR8121/AR8113/AR8114 Ethernet
++#device		bce		# Broadcom BCM5706/BCM5708 Gigabit Ethernet
++#device		bfe		# Broadcom BCM440x 10/100 Ethernet
++#device		bge		# Broadcom BCM570xx Gigabit Ethernet
++#device		dc		# DEC/Intel 21143 and various workalikes
++#device		et		# Agere ET1310 10/100/Gigabit Ethernet
++#device		fxp		# Intel EtherExpress PRO/100B (82557, 82558)
++#device		jme		# JMicron JMC250 Gigabit/JMC260 Fast Ethernet
++#device		lge		# Level 1 LXT1001 gigabit Ethernet
++#device		msk		# Marvell/SysKonnect Yukon II Gigabit Ethernet
++#device		nfe		# nVidia nForce MCP on-board Ethernet
++#device		nge		# NatSemi DP83820 gigabit Ethernet
++#device		nve		# nVidia nForce MCP on-board Ethernet Networking
++#device		pcn		# AMD Am79C97x PCI 10/100 (precedence over 'le')
++#device		re		# RealTek 8139C+/8169/8169S/8110S
++#device		rl		# RealTek 8129/8139
++#device		sf		# Adaptec AIC-6915 (``Starfire'')
++#device		sge		# Silicon Integrated Systems SiS190/191
++#device		sis		# Silicon Integrated Systems SiS 900/SiS 7016
++#device		sk		# SysKonnect SK-984x & SK-982x gigabit Ethernet
++#device		ste		# Sundance ST201 (D-Link DFE-550TX)
++#device		stge		# Sundance/Tamarack TC9021 gigabit Ethernet
++#device		tl		# Texas Instruments ThunderLAN
++#device		tx		# SMC EtherPower II (83c170 ``EPIC'')
++#device		vge		# VIA VT612x gigabit Ethernet
++#device		vr		# VIA Rhine, Rhine II
++#device		wb		# Winbond W89C840F
++#device		xl		# 3Com 3c90x (``Boomerang'', ``Cyclone'')
++
++# ISA Ethernet NICs.  pccard NICs included.
++#device		cs		# Crystal Semiconductor CS89x0 NIC
++# 'device ed' requires 'device miibus'
++device		ed		# NE[12]000, SMC Ultra, 3c503, DS8390 cards
++#device		ex		# Intel EtherExpress Pro/10 and Pro/10+
++#device		ep		# Etherlink III based cards
++#device		fe		# Fujitsu MB8696x based cards
++#device		sn		# SMC's 9000 series of Ethernet chips
++#device		xe		# Xircom pccard Ethernet
++
++# Wireless NIC cards
++#device		wlan		# 802.11 support
++#options 	IEEE80211_DEBUG	# enable debug msgs
++#options 	IEEE80211_AMPDU_AGE # age frames in AMPDU reorder q's
++#options 	IEEE80211_SUPPORT_MESH	# enable 802.11s draft support
++#device		wlan_wep	# 802.11 WEP support
++#device		wlan_ccmp	# 802.11 CCMP support
++#device		wlan_tkip	# 802.11 TKIP support
++#device		wlan_amrr	# AMRR transmit rate control algorithm
++#device		an		# Aironet 4500/4800 802.11 wireless NICs.
++#device		ath		# Atheros NIC's
++#device		ath_pci		# Atheros pci/cardbus glue
++#device		ath_hal		# pci/cardbus chip support
++#options 	AH_SUPPORT_AR5416	# enable AR5416 tx/rx descriptors
++#device		ath_rate_sample	# SampleRate tx rate control for ath
++#device		bwi		# Broadcom BCM430x/BCM431x wireless NICs.
++#device		bwn		# Broadcom BCM43xx wireless NICs.
++#device		ipw		# Intel 2100 wireless NICs.
++#device		iwi		# Intel 2200BG/2225BG/2915ABG wireless NICs.
++#device		iwn		# Intel 4965/1000/5000/6000 wireless NICs.
++#device		malo		# Marvell Libertas wireless NICs.
++#device		mwl		# Marvell 88W8363 802.11n wireless NICs.
++#device		ral		# Ralink Technology RT2500 wireless NICs.
++#device		wi		# WaveLAN/Intersil/Symbol 802.11 wireless NICs.
++#device		wpi		# Intel 3945ABG wireless NICs.
++
++# Pseudo devices.
++device		loop		# Network loopback
++device		random		# Entropy device
++device		ether		# Ethernet support
++device		vlan		# 802.1Q VLAN support
++device		tun		# Packet tunnel.
++device		pty		# BSD-style compatibility pseudo ttys
++device		md		# Memory "disks"
++device		gif		# IPv6 and IPv4 tunneling
++device		faith		# IPv6-to-IPv4 relaying (translation)
++device		firmware	# firmware assist module
++
++# The `bpf' device enables the Berkeley Packet Filter.
++# Be aware of the administrative consequences of enabling this!
++# Note that 'bpf' is required for DHCP.
++device		bpf		# Berkeley packet filter
++
++# USB support
++options 	USB_DEBUG	# enable debug msgs
++device		uhci		# UHCI PCI->USB interface
++device		ohci		# OHCI PCI->USB interface
++device		ehci		# EHCI PCI->USB interface (USB 2.0)
++device		xhci		# XHCI PCI->USB interface (USB 3.0)
++device		usb		# USB Bus (required)
++#device		udbp		# USB Double Bulk Pipe devices (needs netgraph)
++device		uhid		# "Human Interface Devices"
++device		ukbd		# Keyboard
++#device		ulpt		# Printer
++device		umass		# Disks/Mass storage - Requires scbus and da
++device		ums		# Mouse
++#device		urio		# Diamond Rio 500 MP3 player
++# USB Serial devices
++#device		u3g		# USB-based 3G modems (Option, Huawei, Sierra)
++#device		uark		# Technologies ARK3116 based serial adapters
++#device		ubsa		# Belkin F5U103 and compatible serial adapters
++#device		uftdi		# For FTDI usb serial adapters
++#device		uipaq		# Some WinCE based devices
++#device		uplcom		# Prolific PL-2303 serial adapters
++#device		uslcom		# SI Labs CP2101/CP2102 serial adapters
++#device		uvisor		# Visor and Palm devices
++#device		uvscom		# USB serial support for DDI pocket's PHS
++# USB Ethernet, requires miibus
++#device		aue		# ADMtek USB Ethernet
++#device		axe		# ASIX Electronics USB Ethernet
++#device		cdce		# Generic USB over Ethernet
++#device		cue		# CATC USB Ethernet
++#device		kue		# Kawasaki LSI USB Ethernet
++#device		rue		# RealTek RTL8150 USB Ethernet
++#device		udav		# Davicom DM9601E USB
++# USB Wireless
++#device		rum		# Ralink Technology RT2501USB wireless NICs
++#device		run		# Ralink Technology RT2700/RT2800/RT3000 NICs.
++#device		uath		# Atheros AR5523 wireless NICs
++#device		upgt		# Conexant/Intersil PrismGT wireless NICs.
++#device		ural		# Ralink Technology RT2500USB wireless NICs
++#device		urtw		# Realtek RTL8187B/L wireless NICs
++#device		zyd		# ZyDAS zd1211/zd1211b wireless NICs
++
++# FireWire support
++#device		firewire	# FireWire bus code
++# sbp(4) works for some systems but causes boot failure on others
++#device		sbp		# SCSI over FireWire (Requires scbus and da)
++#device		fwe		# Ethernet over FireWire (non-standard!)
++#device		fwip		# IP over FireWire (RFC 2734,3146)
++#device		dcons		# Dumb console driver
++#device		dcons_crom	# Configuration ROM for dcons
++
++# Sound support
++#device		sound		# Generic sound driver (required)
++#device		snd_es137x	# Ensoniq AudioPCI ES137x
++#device		snd_hda		# Intel High Definition Audio
++#device		snd_ich		# Intel, NVidia and other ICH AC'97 Audio
++#device		snd_uaudio	# USB Audio
++#device		snd_via8233	# VIA VT8233x Audio
+diff --git a/sys/amd64/conf/SVAMAC b/sys/amd64/conf/SVAMAC
+new file mode 100644
+index 00000000..a20e7e5b
+--- /dev/null
++++ b/sys/amd64/conf/SVAMAC
+@@ -0,0 +1,342 @@
++#
++# GENERIC -- Generic kernel configuration file for FreeBSD/amd64
++#
++# For more information on this file, please read the config(5) manual page,
++# and/or the handbook section on Kernel Configuration Files:
++#
++#    http://www.FreeBSD.org/doc/en_US.ISO8859-1/books/handbook/kernelconfig-config.html
++#
++# The handbook is also available locally in /usr/share/doc/handbook
++# if you've installed the doc distribution, otherwise always see the
++# FreeBSD World Wide Web server (http://www.FreeBSD.org/) for the
++# latest information.
++#
++# An exhaustive list of options and more detailed explanations of the
++# device lines is also present in the ../../conf/NOTES and NOTES files.
++# If you are in doubt as to the purpose or necessity of a line, check first
++# in NOTES.
++#
++# $FreeBSD: release/9.0.0/sys/amd64/conf/GENERIC 227305 2011-11-07 13:40:54Z marius $
++
++cpu		HAMMER
++ident		SVAMAC
++
++makeoptions	DEBUG=-g		# Build kernel with gdb(1) debug symbols
++
++#options 	SCHED_ULE		# ULE scheduler
++options   SCHED_4BSD
++options 	PREEMPTION		# Enable kernel thread preemption
++options 	INET			# InterNETworking
++options 	INET6			# IPv6 communications protocols
++options 	SCTP			# Stream Control Transmission Protocol
++options 	FFS			# Berkeley Fast Filesystem
++options 	SOFTUPDATES		# Enable FFS soft updates support
++options 	UFS_ACL			# Support for access control lists
++options 	UFS_DIRHASH		# Improve performance on big directories
++options 	UFS_GJOURNAL		# Enable gjournal-based UFS journaling
++options 	MD_ROOT			# MD is a potential root device
++options 	NFSCL			# New Network Filesystem Client
++options 	NFSD			# New Network Filesystem Server
++options 	NFSLOCKD		# Network Lock Manager
++options 	NFS_ROOT		# NFS usable as /, requires NFSCL
++options 	MSDOSFS			# MSDOS Filesystem
++options 	CD9660			# ISO 9660 Filesystem
++options 	PROCFS			# Process filesystem (requires PSEUDOFS)
++options 	PSEUDOFS		# Pseudo-filesystem framework
++options 	GEOM_PART_GPT		# GUID Partition Tables.
++options 	GEOM_LABEL		# Provides labelization
++options 	COMPAT_FREEBSD32	# Compatible with i386 binaries
++options 	COMPAT_FREEBSD4		# Compatible with FreeBSD4
++options 	COMPAT_FREEBSD5		# Compatible with FreeBSD5
++options 	COMPAT_FREEBSD6		# Compatible with FreeBSD6
++options 	COMPAT_FREEBSD7		# Compatible with FreeBSD7
++options 	SCSI_DELAY=5000		# Delay (in ms) before probing SCSI
++options 	KTRACE			# ktrace(1) support
++options 	STACK			# stack(9) support
++options 	SYSVSHM			# SYSV-style shared memory
++options 	SYSVMSG			# SYSV-style message queues
++options 	SYSVSEM			# SYSV-style semaphores
++options 	_KPOSIX_PRIORITY_SCHEDULING # POSIX P1003_1B real-time extensions
++options 	PRINTF_BUFR_SIZE=128	# Prevent printf output being interspersed.
++options 	KBD_INSTALL_CDEV	# install a CDEV entry in /dev
++options 	HWPMC_HOOKS		# Necessary kernel hooks for hwpmc(4)
++options 	AUDIT			# Security event auditing
++options 	MAC			# TrustedBSD MAC Framework
++#options 	KDTRACE_FRAME		# Ensure frames are compiled in
++#options 	KDTRACE_HOOKS		# Kernel DTrace hooks
++options 	INCLUDE_CONFIG_FILE     # Include this file in kernel
++options 	KDB			# Kernel debugger related code
++options 	KDB_TRACE		# Print a stack trace for a panic
++options		DDB
++options		BREAK_TO_DEBUGGER # Break signal on console goes into debugger
++options		ALT_BREAK_TO_DEBUGGER # Break signal on console goes into debugger
++
++# Make an SMP-capable kernel by default
++#options 	SMP			# Symmetric MultiProcessor Kernel
++
++# CPU frequency control
++device		cpufreq
++
++# Bus support.
++device		acpi
++device		pci
++
++# Floppy drives
++device		fdc
++
++# ATA controllers
++device		ahci		# AHCI-compatible SATA controllers
++device		ata		# Legacy ATA/SATA controllers
++options 	ATA_CAM		# Handle legacy controllers with CAM
++options 	ATA_STATIC_ID	# Static device numbering
++device		mvs		# Marvell 88SX50XX/88SX60XX/88SX70XX/SoC SATA
++device		siis		# SiliconImage SiI3124/SiI3132/SiI3531 SATA
++
++# SCSI Controllers
++device		ahc		# AHA2940 and onboard AIC7xxx devices
++options 	AHC_REG_PRETTY_PRINT	# Print register bitfields in debug
++					# output.  Adds ~128k to driver.
++device		ahd		# AHA39320/29320 and onboard AIC79xx devices
++options 	AHD_REG_PRETTY_PRINT	# Print register bitfields in debug
++					# output.  Adds ~215k to driver.
++device		esp		# AMD Am53C974 (Tekram DC-390(T))
++device		hptiop		# Highpoint RocketRaid 3xxx series
++device		isp		# Qlogic family
++#device		ispfw		# Firmware for QLogic HBAs- normally a module
++device		mpt		# LSI-Logic MPT-Fusion
++device		mps		# LSI-Logic MPT-Fusion 2
++#device		ncr		# NCR/Symbios Logic
++device		sym		# NCR/Symbios Logic (newer chipsets + those of `ncr')
++device		trm		# Tekram DC395U/UW/F DC315U adapters
++
++device		adv		# Advansys SCSI adapters
++device		adw		# Advansys wide SCSI adapters
++device		aic		# Adaptec 15[012]x SCSI adapters, AIC-6[23]60.
++device		bt		# Buslogic/Mylex MultiMaster SCSI adapters
++
++# ATA/SCSI peripherals
++device		scbus		# SCSI bus (required for ATA/SCSI)
++device		ch		# SCSI media changers
++device		da		# Direct Access (disks)
++device		sa		# Sequential Access (tape etc)
++device		cd		# CD
++device		pass		# Passthrough device (direct ATA/SCSI access)
++device		ses		# SCSI Environmental Services (and SAF-TE)
++
++# RAID controllers interfaced to the SCSI subsystem
++device		amr		# AMI MegaRAID
++device		arcmsr		# Areca SATA II RAID
++#XXX it is not 64-bit clean, -scottl
++#device		asr		# DPT SmartRAID V, VI and Adaptec SCSI RAID
++device		ciss		# Compaq Smart RAID 5*
++device		dpt		# DPT Smartcache III, IV - See NOTES for options
++device		hptmv		# Highpoint RocketRAID 182x
++device		hptrr		# Highpoint RocketRAID 17xx, 22xx, 23xx, 25xx
++device		iir		# Intel Integrated RAID
++device		ips		# IBM (Adaptec) ServeRAID
++device		mly		# Mylex AcceleRAID/eXtremeRAID
++device		twa		# 3ware 9000 series PATA/SATA RAID
++
++# RAID controllers
++device		aac		# Adaptec FSA RAID
++device		aacp		# SCSI passthrough for aac (requires CAM)
++device		ida		# Compaq Smart RAID
++device		mfi		# LSI MegaRAID SAS
++device		mlx		# Mylex DAC960 family
++#XXX pointer/int warnings
++#device		pst		# Promise Supertrak SX6000
++device		twe		# 3ware ATA RAID
++device		tws		# LSI 3ware 9750 SATA+SAS 6Gb/s RAID controller
++
++# atkbdc0 controls both the keyboard and the PS/2 mouse
++device		atkbdc		# AT keyboard controller
++device		atkbd		# AT keyboard
++device		psm		# PS/2 mouse
++
++device		kbdmux		# keyboard multiplexer
++
++device		vga		# VGA video card driver
++
++device		splash		# Splash screen and screen saver support
++
++# syscons is the default console driver, resembling an SCO console
++device		sc
++options 	SC_PIXEL_MODE	# add support for the raster text mode
++
++device		agp		# support several AGP chipsets
++
++# PCCARD (PCMCIA) support
++# PCMCIA and cardbus bridge support
++device		cbb		# cardbus (yenta) bridge
++device		pccard		# PC Card (16-bit) bus
++device		cardbus		# CardBus (32-bit) bus
++
++# Serial (COM) ports
++device		uart		# Generic UART driver
++
++# Parallel port
++device		ppc
++device		ppbus		# Parallel port bus (required)
++device		lpt		# Printer
++device		plip		# TCP/IP over parallel
++device		ppi		# Parallel port interface device
++#device		vpo		# Requires scbus and da
++
++device		puc		# Multi I/O cards and multi-channel UARTs
++
++# PCI Ethernet NICs.
++device		bxe		# Broadcom BCM57710/BCM57711/BCM57711E 10Gb Ethernet
++device		de		# DEC/Intel DC21x4x (``Tulip'')
++device		em		# Intel PRO/1000 Gigabit Ethernet Family
++device		igb		# Intel PRO/1000 PCIE Server Gigabit Family
++device		ixgbe		# Intel PRO/10GbE PCIE Ethernet Family
++device		le		# AMD Am7900 LANCE and Am79C9xx PCnet
++device		ti		# Alteon Networks Tigon I/II gigabit Ethernet
++device		txp		# 3Com 3cR990 (``Typhoon'')
++device		vx		# 3Com 3c590, 3c595 (``Vortex'')
++
++# PCI Ethernet NICs that use the common MII bus controller code.
++# NOTE: Be sure to keep the 'device miibus' line in order to use these NICs!
++device		miibus		# MII bus support
++device		ae		# Attansic/Atheros L2 FastEthernet
++device		age		# Attansic/Atheros L1 Gigabit Ethernet
++device		alc		# Atheros AR8131/AR8132 Ethernet
++device		ale		# Atheros AR8121/AR8113/AR8114 Ethernet
++device		bce		# Broadcom BCM5706/BCM5708 Gigabit Ethernet
++device		bfe		# Broadcom BCM440x 10/100 Ethernet
++device		bge		# Broadcom BCM570xx Gigabit Ethernet
++device		dc		# DEC/Intel 21143 and various workalikes
++device		et		# Agere ET1310 10/100/Gigabit Ethernet
++device		fxp		# Intel EtherExpress PRO/100B (82557, 82558)
++device		jme		# JMicron JMC250 Gigabit/JMC260 Fast Ethernet
++device		lge		# Level 1 LXT1001 gigabit Ethernet
++device		msk		# Marvell/SysKonnect Yukon II Gigabit Ethernet
++device		nfe		# nVidia nForce MCP on-board Ethernet
++device		nge		# NatSemi DP83820 gigabit Ethernet
++#device		nve		# nVidia nForce MCP on-board Ethernet Networking
++device		pcn		# AMD Am79C97x PCI 10/100 (precedence over 'le')
++device		re		# RealTek 8139C+/8169/8169S/8110S
++device		rl		# RealTek 8129/8139
++device		sf		# Adaptec AIC-6915 (``Starfire'')
++device		sge		# Silicon Integrated Systems SiS190/191
++device		sis		# Silicon Integrated Systems SiS 900/SiS 7016
++device		sk		# SysKonnect SK-984x & SK-982x gigabit Ethernet
++device		ste		# Sundance ST201 (D-Link DFE-550TX)
++device		stge		# Sundance/Tamarack TC9021 gigabit Ethernet
++device		tl		# Texas Instruments ThunderLAN
++device		tx		# SMC EtherPower II (83c170 ``EPIC'')
++device		vge		# VIA VT612x gigabit Ethernet
++device		vr		# VIA Rhine, Rhine II
++device		wb		# Winbond W89C840F
++device		xl		# 3Com 3c90x (``Boomerang'', ``Cyclone'')
++
++# ISA Ethernet NICs.  pccard NICs included.
++device		cs		# Crystal Semiconductor CS89x0 NIC
++# 'device ed' requires 'device miibus'
++device		ed		# NE[12]000, SMC Ultra, 3c503, DS8390 cards
++device		ex		# Intel EtherExpress Pro/10 and Pro/10+
++device		ep		# Etherlink III based cards
++device		fe		# Fujitsu MB8696x based cards
++device		sn		# SMC's 9000 series of Ethernet chips
++device		xe		# Xircom pccard Ethernet
++
++# Wireless NIC cards
++device		wlan		# 802.11 support
++options 	IEEE80211_DEBUG	# enable debug msgs
++options 	IEEE80211_AMPDU_AGE # age frames in AMPDU reorder q's
++options 	IEEE80211_SUPPORT_MESH	# enable 802.11s draft support
++device		wlan_wep	# 802.11 WEP support
++device		wlan_ccmp	# 802.11 CCMP support
++device		wlan_tkip	# 802.11 TKIP support
++device		wlan_amrr	# AMRR transmit rate control algorithm
++device		an		# Aironet 4500/4800 802.11 wireless NICs.
++device		ath		# Atheros NIC's
++device		ath_pci		# Atheros pci/cardbus glue
++device		ath_hal		# pci/cardbus chip support
++options 	AH_SUPPORT_AR5416	# enable AR5416 tx/rx descriptors
++device		ath_rate_sample	# SampleRate tx rate control for ath
++#device		bwi		# Broadcom BCM430x/BCM431x wireless NICs.
++#device		bwn		# Broadcom BCM43xx wireless NICs.
++device		ipw		# Intel 2100 wireless NICs.
++device		iwi		# Intel 2200BG/2225BG/2915ABG wireless NICs.
++device		iwn		# Intel 4965/1000/5000/6000 wireless NICs.
++device		malo		# Marvell Libertas wireless NICs.
++device		mwl		# Marvell 88W8363 802.11n wireless NICs.
++device		ral		# Ralink Technology RT2500 wireless NICs.
++device		wi		# WaveLAN/Intersil/Symbol 802.11 wireless NICs.
++device		wpi		# Intel 3945ABG wireless NICs.
++
++# Pseudo devices.
++device		loop		# Network loopback
++device		random		# Entropy device
++device		ether		# Ethernet support
++device		vlan		# 802.1Q VLAN support
++device		tun		# Packet tunnel.
++device		pty		# BSD-style compatibility pseudo ttys
++device		md		# Memory "disks"
++device		gif		# IPv6 and IPv4 tunneling
++device		faith		# IPv6-to-IPv4 relaying (translation)
++device		firmware	# firmware assist module
++
++# The `bpf' device enables the Berkeley Packet Filter.
++# Be aware of the administrative consequences of enabling this!
++# Note that 'bpf' is required for DHCP.
++device		bpf		# Berkeley packet filter
++
++# USB support
++options 	USB_DEBUG	# enable debug msgs
++device		uhci		# UHCI PCI->USB interface
++device		ohci		# OHCI PCI->USB interface
++device		ehci		# EHCI PCI->USB interface (USB 2.0)
++device		xhci		# XHCI PCI->USB interface (USB 3.0)
++device		usb		# USB Bus (required)
++#device		udbp		# USB Double Bulk Pipe devices (needs netgraph)
++device		uhid		# "Human Interface Devices"
++device		ukbd		# Keyboard
++device		ulpt		# Printer
++device		umass		# Disks/Mass storage - Requires scbus and da
++device		ums		# Mouse
++device		urio		# Diamond Rio 500 MP3 player
++# USB Serial devices
++device		u3g		# USB-based 3G modems (Option, Huawei, Sierra)
++device		uark		# Technologies ARK3116 based serial adapters
++device		ubsa		# Belkin F5U103 and compatible serial adapters
++device		uftdi		# For FTDI usb serial adapters
++device		uipaq		# Some WinCE based devices
++device		uplcom		# Prolific PL-2303 serial adapters
++device		uslcom		# SI Labs CP2101/CP2102 serial adapters
++device		uvisor		# Visor and Palm devices
++device		uvscom		# USB serial support for DDI pocket's PHS
++# USB Ethernet, requires miibus
++device		aue		# ADMtek USB Ethernet
++device		axe		# ASIX Electronics USB Ethernet
++device		cdce		# Generic USB over Ethernet
++device		cue		# CATC USB Ethernet
++device		kue		# Kawasaki LSI USB Ethernet
++device		rue		# RealTek RTL8150 USB Ethernet
++device		udav		# Davicom DM9601E USB
++# USB Wireless
++device		rum		# Ralink Technology RT2501USB wireless NICs
++device		run		# Ralink Technology RT2700/RT2800/RT3000 NICs.
++device		uath		# Atheros AR5523 wireless NICs
++device		upgt		# Conexant/Intersil PrismGT wireless NICs.
++device		ural		# Ralink Technology RT2500USB wireless NICs
++device		urtw		# Realtek RTL8187B/L wireless NICs
++device		zyd		# ZyDAS zd1211/zd1211b wireless NICs
++
++# FireWire support
++device		firewire	# FireWire bus code
++# sbp(4) works for some systems but causes boot failure on others
++#device		sbp		# SCSI over FireWire (Requires scbus and da)
++device		fwe		# Ethernet over FireWire (non-standard!)
++device		fwip		# IP over FireWire (RFC 2734,3146)
++device		dcons		# Dumb console driver
++device		dcons_crom	# Configuration ROM for dcons
++
++# Sound support
++device		sound		# Generic sound driver (required)
++device		snd_es137x	# Ensoniq AudioPCI ES137x
++device		snd_hda		# Intel High Definition Audio
++device		snd_ich		# Intel, NVidia and other ICH AC'97 Audio
++device		snd_uaudio	# USB Audio
++device		snd_via8233	# VIA VT8233x Audio
 diff --git a/sys/amd64/ia32/ia32_syscall.c b/sys/amd64/ia32/ia32_syscall.c
 index 0e27f04b..1a46058a 100644
 --- a/sys/amd64/ia32/ia32_syscall.c
@@ -5316,6 +6275,159 @@ index 1578a66b..66ba8bba 100644
  
  	newtd->td_pflags |= TDP_KTHREAD;
  	newtd->td_ucred = crhold(p->p_ucred);
+diff --git a/sys/kern/kern_sva.c b/sys/kern/kern_sva.c
+new file mode 100644
+index 00000000..05b63a53
+--- /dev/null
++++ b/sys/kern/kern_sva.c
+@@ -0,0 +1,147 @@
++/*===- kern_sva.c - SVA Kernel Callbacks =-----------------------------------===
++ * 
++ *                        Secure Virtual Architecture
++ *
++ * This file was developed by the LLVM research group and is distributed under
++ * the University of Illinois Open Source License. See LICENSE.TXT for details.
++ * 
++ *===----------------------------------------------------------------------===
++ *
++ * This file implements functions that the kernel needs to provide to SVA.
++ *
++ *===----------------------------------------------------------------------===
++ */
++
++#include <sys/malloc.h>
++#include <sys/types.h>
++#include <sys/proc.h>
++
++#include <sys/cdefs.h>
++#include <vm/vm.h>
++#include <vm/vm_param.h>
++#include <vm/vm_kern.h>
++#include <vm/vm_page.h>
++#include <vm/vm_map.h>
++#include <vm/vm_object.h>
++#include <vm/vm_extern.h>
++#include <vm/vm_pageout.h>
++#include <vm/vm_reserv.h>
++#include <vm/pmap.h>
++#include <vm/uma.h>
++
++#include <sys/pcpu.h>
++#include <machine/frame.h>
++
++/* Function prototypes */
++uintptr_t provideSVAMemory (uintptr_t size);
++void releaseSVAMemory (uintptr_t p, uintptr_t size);
++
++/*
++ * Function: provideSVAMemory()
++ *
++ * Description:
++ *  Allocate memory and pass it to SVA to use.
++ *
++ * Inputs:
++ *  The amount of memory to give SVA in bytes.
++ *
++ * Return value:
++ *  The first physical address of the memory that SVA can use.
++ */
++uintptr_t
++provideSVAMemory (uintptr_t size)
++{
++  /* Structure to get a page */
++  vm_page_t bufferPage;
++
++  /* Virtual address of memory to be returned. */
++  unsigned char * p;
++
++  /*
++   * Check to see if a single page will do.  If not, then panic.
++   */
++  if (size > 4096u)
++    panic ("SVA: providesSVAMemory: Too much memory requested: %ld\n", size);
++
++  /*
++   * Request a page from the page manager.
++   */
++	bufferPage = vm_page_alloc (NULL, 0, VM_ALLOC_NORMAL | VM_ALLOC_NOOBJ);
++
++  /*
++   * Unmap the page from the 1 TB direct map.
++   */
++	p = (void *) PHYS_TO_DMAP(VM_PAGE_TO_PHYS(bufferPage));
++  pmap_remove (&(curproc->p_vmspace->vm_pmap),
++               (vm_offset_t) p,
++               (vm_offset_t) p + 4096);
++
++  /*
++   * Convert the page into a physical address and return it.
++   */
++	return VM_PAGE_TO_PHYS(bufferPage);
++}
++
++/*
++ * Function: releaseSVAMemory()
++ *
++ * Description:
++ *  SVA calls this function when it no longer needs a piece of memory.
++ *
++ * Inputs:
++ *  paddr - The first physical address of the memory to release back to the OS.
++ *  size  - The length of the memory in bytes to release.
++ *
++ */
++void
++releaseSVAMemory (uintptr_t paddr, uintptr_t size)
++{
++  /* Paging structure for the memory */
++  vm_page_t page;
++
++  /*
++   * Convert the physical address into a vm_page_t.
++   */
++  page = vm_phys_paddr_to_vm_page (paddr);
++
++  /*
++   * Figure out where in the virtual address space it should go.
++   */
++	unsigned char * p = (void *) PHYS_TO_DMAP(VM_PAGE_TO_PHYS(page));
++
++  /*
++   * Remap the page back into the direct 1 TB map.
++   */
++  pmap_enter (&(curproc->p_vmspace->vm_pmap),
++               (vm_offset_t) p,
++               0,
++               page,
++               VM_PROT_READ | VM_PROT_WRITE,
++               0);
++
++  /*
++   * Now free the page.
++   */
++  vm_page_free (page);
++  return;
++}
++
++/*
++ * Function: testSVAMemory()
++ *
++ * Description:
++ *  Try to access secure memory.
++ */
++void
++testSVAMemory (unsigned char * p) {
++  /*
++   * Testing time: Attempt to access the secure memory.
++   */
++  printf ("Kernel: Spying on you!  Secret is: \n");
++  for (int index = 0; index < 5; ++index) {
++    printf ("%c", p[index]);
++  }
++  printf ("\n");
++  return;
++}
++
 diff --git a/sys/kern/sched_4bsd.c b/sys/kern/sched_4bsd.c
 index 06d55cd1..ba6f7bfd 100644
 --- a/sys/kern/sched_4bsd.c

--- a/freebsd9_patch
+++ b/freebsd9_patch
@@ -1,5 +1,5 @@
 diff --git a/lib/libc/stdlib/malloc.c b/lib/libc/stdlib/malloc.c
-index fb634f80..31eed581 100644
+index fb634f80..47e9bea8 100644
 --- a/lib/libc/stdlib/malloc.c
 +++ b/lib/libc/stdlib/malloc.c
 @@ -155,7 +155,10 @@
@@ -90,7 +90,7 @@ index fb634f80..31eed581 100644
   */
 +
 +/* SVA: No TLS support for now */
-+#define NO_TLS
++//#define NO_TLS
 +
  #ifdef __i386__
  #  define LG_QUANTUM		4
@@ -674,7 +674,7 @@ index 0706fa61..e84c5ad0 100644
  	jmp	0b
  
 diff --git a/sys/amd64/amd64/machdep.c b/sys/amd64/amd64/machdep.c
-index 0890c1b0..52bcfb26 100644
+index 0890c1b0..6a01502a 100644
 --- a/sys/amd64/amd64/machdep.c
 +++ b/sys/amd64/amd64/machdep.c
 @@ -55,6 +55,7 @@ __FBSDID("$FreeBSD: release/9.0.0/sys/amd64/amd64/machdep.c 225617 2011-09-16 13
@@ -700,15 +700,22 @@ index 0890c1b0..52bcfb26 100644
  /* Sanity check for __curthread() */
  CTASSERT(offsetof(struct pcpu, pc_curthread) == 0);
  
-@@ -334,6 +343,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
+@@ -334,20 +343,28 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
  	sf.sf_uc.uc_stack = td->td_sigstk;
  	sf.sf_uc.uc_stack.ss_flags = (td->td_pflags & TDP_ALTSTACK)
  	    ? ((oonstack) ? SS_ONSTACK : 0) : SS_DISABLE;
++
++	sf.sf_uc.uc_mcontext.mc_fsbase = pcb->pcb_fsbase;	/* fsbase */
++
 +#if 0
  	sf.sf_uc.uc_mcontext.mc_onstack = (oonstack) ? 1 : 0;
  	bcopy(regs, &sf.sf_uc.uc_mcontext.mc_rdi, sizeof(*regs));
  	sf.sf_uc.uc_mcontext.mc_len = sizeof(sf.sf_uc.uc_mcontext); /* magic */
-@@ -344,10 +354,14 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
+ 	get_fpcontext(td, &sf.sf_uc.uc_mcontext);
+ 	fpstate_drop(td);
+-	sf.sf_uc.uc_mcontext.mc_fsbase = pcb->pcb_fsbase;
++	sf.sf_uc.uc_mcontext.mc_fsbase = pcb->pcb_fsbase;	/* fsbase */
+ 	sf.sf_uc.uc_mcontext.mc_gsbase = pcb->pcb_gsbase;
  	bzero(sf.sf_uc.uc_mcontext.mc_spare,
  	    sizeof(sf.sf_uc.uc_mcontext.mc_spare));
  	bzero(sf.sf_uc.__spare__, sizeof(sf.sf_uc.__spare__));
@@ -723,7 +730,7 @@ index 0890c1b0..52bcfb26 100644
  		sp = td->td_sigstk.ss_sp +
  		    td->td_sigstk.ss_size - sizeof(struct sigframe);
  #if defined(COMPAT_43)
-@@ -363,27 +377,69 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
+@@ -363,27 +380,69 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
  		sig = p->p_sysent->sv_sigtbl[_SIG_IDX(sig)];
  
  	/* Build the argument list for the signal handler. */
@@ -793,17 +800,22 @@ index 0890c1b0..52bcfb26 100644
  	/*
  	 * Copy the sigframe out to the user's stack.
  	 */
-@@ -394,7 +450,9 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
+@@ -394,7 +453,14 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
  		PROC_LOCK(p);
  		sigexit(td, SIGILL);
  	}
 +#endif
  
++	regs->tf_cs = _ucodesel;		/* this would affect tls */
++	regs->tf_fs = _ufssel;			/* this would affect tls */
++	regs->tf_flags = TF_HASSEGS;
++	set_pcb_flags(pcb, PCB_FULL_IRET); /* this would affect tls */
++
 +#if 0
  	regs->tf_rsp = (long)sfp;
  	regs->tf_rip = p->p_sysent->sv_sigcode_base;
  	regs->tf_rflags &= ~(PSL_T | PSL_D);
-@@ -405,6 +463,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
+@@ -405,6 +471,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
  	regs->tf_gs = _ugssel;
  	regs->tf_flags = TF_HASSEGS;
  	set_pcb_flags(pcb, PCB_FULL_IRET);
@@ -811,7 +823,7 @@ index 0890c1b0..52bcfb26 100644
  	PROC_LOCK(p);
  	mtx_lock(&psp->ps_mtx);
  }
-@@ -436,8 +495,14 @@ sys_sigreturn(td, uap)
+@@ -436,8 +503,17 @@ sys_sigreturn(td, uap)
  	int cs, error, ret;
  	ksiginfo_t ksi;
  
@@ -823,22 +835,51 @@ index 0890c1b0..52bcfb26 100644
  	pcb = td->td_pcb;
  	p = td->td_proc;
 +#endif
++
++	pcb = td->td_pcb;		/** to recover fsbase related operations */
++	p = td->td_proc;
  
  	error = copyin(uap->sigcntxp, &uc, sizeof(uc));
  	if (error != 0) {
-@@ -446,6 +511,7 @@ sys_sigreturn(td, uap)
+@@ -446,13 +522,17 @@ sys_sigreturn(td, uap)
  		return (error);
  	}
  	ucp = &uc;
+-	if ((ucp->uc_mcontext.mc_flags & ~_MC_FLAG_MASK) != 0) {
++
++	regs = td->td_frame;						/**for fsbase **/
++
 +#if 0
- 	if ((ucp->uc_mcontext.mc_flags & ~_MC_FLAG_MASK) != 0) {
++	if ((ucp->uc_mcontext.mc_flags & ~_MC_FLAG_MASK) != 0) {		/**  for fsbase **/
  		uprintf("pid %d (%s): sigreturn mc_flags %x\n", p->p_pid,
  		    td->td_name, ucp->uc_mcontext.mc_flags);
-@@ -506,9 +572,17 @@ sys_sigreturn(td, uap)
+ 		return (EINVAL);
+ 	}
+-	regs = td->td_frame;
+-	rflags = ucp->uc_mcontext.mc_rflags;
++	regs = td->td_frame;						/**for fsbase **/
++	rflags = ucp->uc_mcontext.mc_rflags;		/** for fsbase **/
+ 	/*
+ 	 * Don't allow users to change privileged or reserved flags.
+ 	 */
+@@ -496,8 +576,8 @@ sys_sigreturn(td, uap)
+ 		    p->p_pid, td->td_name, ret);
+ 		return (ret);
+ 	}
+-	bcopy(&ucp->uc_mcontext.mc_rdi, regs, sizeof(*regs));
+-	pcb->pcb_fsbase = ucp->uc_mcontext.mc_fsbase;
++	bcopy(&ucp->uc_mcontext.mc_rdi, regs, sizeof(*regs));	/* for fsbase */
++	pcb->pcb_fsbase = ucp->uc_mcontext.mc_fsbase;			/* this fsbase related to TLS */
+ 	pcb->pcb_gsbase = ucp->uc_mcontext.mc_gsbase;
+ 
+ #if defined(COMPAT_43)
+@@ -506,9 +586,20 @@ sys_sigreturn(td, uap)
  	else
  		td->td_sigstk.ss_flags &= ~SS_ONSTACK;
  #endif
 +#endif
++
++	pcb->pcb_fsbase = ucp->uc_mcontext.mc_fsbase;			/* this fsbase related to TLS */
 +
 +#if 1
 +  /* Load the old interrupted state back on into the interrupt context. */
@@ -846,29 +887,54 @@ index 0890c1b0..52bcfb26 100644
 +#endif
  
  	kern_sigprocmask(td, SIG_SETMASK, &ucp->uc_sigmask, NULL, 0);
+-	set_pcb_flags(pcb, PCB_FULL_IRET);
 +#if 0
- 	set_pcb_flags(pcb, PCB_FULL_IRET);
++	set_pcb_flags(pcb, PCB_FULL_IRET); /* for fsbase */
 +#endif
++	set_pcb_flags(pcb, PCB_FULL_IRET); /* for fsbase */
  	return (EJUSTRETURN);
  }
  
-@@ -885,10 +959,13 @@ exec_setregs(struct thread *td, struct image_params *imgp, u_long stack)
+@@ -885,11 +976,25 @@ exec_setregs(struct thread *td, struct image_params *imgp, u_long stack)
  	else
  		mtx_unlock(&dt_lock);
  	
+-	pcb->pcb_fsbase = 0;
++	pcb->pcb_fsbase = 0;	/** fsbase **/
++
 +#if 0
- 	pcb->pcb_fsbase = 0;
  	pcb->pcb_gsbase = 0;
- 	clear_pcb_flags(pcb, PCB_32BIT | PCB_GS32BIT);
 +#endif
+ 	clear_pcb_flags(pcb, PCB_32BIT | PCB_GS32BIT);
++
  	pcb->pcb_initial_fpucw = __INITIAL_FPUCW__;
-+#if 0
++
++	/* re-enable fsbase related regs.*/
  	set_pcb_flags(pcb, PCB_FULL_IRET);
++	bzero((char *)regs, sizeof(struct trapframe));
++	regs->tf_rflags = PSL_USER | (regs->tf_rflags & PSL_T); /* TODO: fsbase related or not? */
++	regs->tf_cs = _ucodesel;		/** for fsbase SEL_RPL_MASK **/
++	regs->tf_fs = _ufssel;			/** fsbase **/
++	regs->tf_flags = TF_HASSEGS; 	/** fsbase **/
++
++#if 0
++	set_pcb_flags(pcb, PCB_FULL_IRET); /* fsbase */
  
  	bzero((char *)regs, sizeof(struct trapframe));
-@@ -904,7 +981,15 @@ exec_setregs(struct thread *td, struct image_params *imgp, u_long stack)
+ 	regs->tf_rip = imgp->entry_addr;
+@@ -897,14 +1002,22 @@ exec_setregs(struct thread *td, struct image_params *imgp, u_long stack)
+ 	regs->tf_rdi = stack;		/* argv */
+ 	regs->tf_rflags = PSL_USER | (regs->tf_rflags & PSL_T);
+ 	regs->tf_ss = _udatasel;
+-	regs->tf_cs = _ucodesel;
++	regs->tf_cs = _ucodesel;	/** for fsbase **/
+ 	regs->tf_ds = _udatasel;
+ 	regs->tf_es = _udatasel;
+-	regs->tf_fs = _ufssel;
++	regs->tf_fs = _ufssel;		/** for fsbase **/
  	regs->tf_gs = _ugssel;
- 	regs->tf_flags = TF_HASSEGS;
+-	regs->tf_flags = TF_HASSEGS;
++	regs->tf_flags = TF_HASSEGS; /** for/** fsbase **/ fsbase **/
  	td->td_retval[1] = 0;
 +#else
 +#if 1
@@ -882,7 +948,7 @@ index 0890c1b0..52bcfb26 100644
  	/*
  	 * Reset the hardware debug registers if they were in use.
  	 * They won't have any meaning for the newly exec'd process.
-@@ -926,6 +1011,7 @@ exec_setregs(struct thread *td, struct image_params *imgp, u_long stack)
+@@ -926,6 +1039,7 @@ exec_setregs(struct thread *td, struct image_params *imgp, u_long stack)
  		}
  		clear_pcb_flags(pcb, PCB_DBREGS);
  	}
@@ -890,7 +956,7 @@ index 0890c1b0..52bcfb26 100644
  
  	/*
  	 * Drop the FP state if we hold it, so that the process gets a
-@@ -945,7 +1031,14 @@ cpu_setregs(void)
+@@ -945,7 +1059,14 @@ cpu_setregs(void)
  	 * BSP.  See the comments there about why we set them.
  	 */
  	cr0 |= CR0_MP | CR0_NE | CR0_TS | CR0_WP | CR0_AM;
@@ -906,7 +972,7 @@ index 0890c1b0..52bcfb26 100644
  }
  
  /*
-@@ -1103,6 +1196,34 @@ setidt(idx, func, typ, dpl, ist)
+@@ -1103,6 +1224,34 @@ setidt(idx, func, typ, dpl, ist)
  {
  	struct gate_descriptor *ip;
  
@@ -941,7 +1007,7 @@ index 0890c1b0..52bcfb26 100644
  	ip = idt + idx;
  	ip->gd_looffset = (uintptr_t)func;
  	ip->gd_selector = GSEL(GCODE_SEL, SEL_KPL);
-@@ -1409,7 +1530,7 @@ getmemsize(caddr_t kmdp, u_int64_t first)
+@@ -1409,7 +1558,7 @@ getmemsize(caddr_t kmdp, u_int64_t first)
  	if (getenv_quad("dcons.addr", &dcons_addr) == 0 ||
  	    getenv_quad("dcons.size", &dcons_size) == 0)
  		dcons_addr = 0;
@@ -950,7 +1016,7 @@ index 0890c1b0..52bcfb26 100644
  	/*
  	 * physmap is in bytes, so when converting to page boundaries,
  	 * round up the start address and round down the end address.
-@@ -1446,7 +1567,13 @@ getmemsize(caddr_t kmdp, u_int64_t first)
+@@ -1446,7 +1595,13 @@ getmemsize(caddr_t kmdp, u_int64_t first)
  			/*
  			 * map page into kernel: valid, read/write,non-cacheable
  			 */
@@ -964,7 +1030,7 @@ index 0890c1b0..52bcfb26 100644
  			invltlb();
  
  			tmp = *(int *)ptr;
-@@ -1528,7 +1655,14 @@ do_next:
+@@ -1528,7 +1683,14 @@ do_next:
  				break;
  		}
  	}
@@ -979,7 +1045,7 @@ index 0890c1b0..52bcfb26 100644
  	invltlb();
  
  	/*
-@@ -1553,6 +1687,19 @@ do_next:
+@@ -1553,6 +1715,19 @@ do_next:
  	msgbufp = (struct msgbuf *)PHYS_TO_DMAP(phys_avail[pa_indx]);
  }
  
@@ -999,7 +1065,7 @@ index 0890c1b0..52bcfb26 100644
  u_int64_t
  hammer_time(u_int64_t modulep, u_int64_t physfree)
  {
-@@ -1611,9 +1758,24 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
+@@ -1611,9 +1786,24 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
  
  	wrmsr(MSR_FSBASE, 0);		/* User value */
  	wrmsr(MSR_GSBASE, (u_int64_t)pc);
@@ -1024,7 +1090,7 @@ index 0890c1b0..52bcfb26 100644
  	dpcpu_init((void *)(physfree + KERNBASE), 0);
  	physfree += DPCPU_SIZE;
  	PCPU_SET(prvspace, pc);
-@@ -1638,35 +1800,79 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
+@@ -1638,35 +1828,79 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
  	mtx_init(&icu_lock, "icu", NULL, MTX_SPIN | MTX_NOWITNESS);
  	mtx_init(&dt_lock, "descriptor tables", NULL, MTX_DEF);
  
@@ -1105,7 +1171,7 @@ index 0890c1b0..52bcfb26 100644
  
  	/*
  	 * Initialize the i8254 before the console so that console
-@@ -1691,8 +1897,13 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
+@@ -1691,8 +1925,13 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
  	 * Point the ICU spurious interrupt vectors at the APIC spurious
  	 * interrupt handler.
  	 */
@@ -1119,7 +1185,7 @@ index 0890c1b0..52bcfb26 100644
  #endif
  #else
  #error "have you forgotten the isa device?";
-@@ -1738,8 +1949,16 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
+@@ -1738,8 +1977,16 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
  	/* Set up the fast syscall stuff */
  	msr = rdmsr(MSR_EFER) | EFER_SCE;
  	wrmsr(MSR_EFER, msr);
@@ -1136,7 +1202,7 @@ index 0890c1b0..52bcfb26 100644
  	msr = ((u_int64_t)GSEL(GCODE_SEL, SEL_KPL) << 32) |
  	      ((u_int64_t)GSEL(GUCODE32_SEL, SEL_UPL) << 48);
  	wrmsr(MSR_STAR, msr);
-@@ -1747,9 +1966,9 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
+@@ -1747,9 +1994,9 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
  
  	getmemsize(kmdp, physfree);
  	init_param2(physmem);
@@ -1148,7 +1214,7 @@ index 0890c1b0..52bcfb26 100644
  	msgbufinit(msgbufp, msgbufsize);
  	fpuinit();
  
-@@ -1770,6 +1989,9 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
+@@ -1770,6 +2017,9 @@ hammer_time(u_int64_t modulep, u_int64_t physfree)
  	thread0.td_pcb->pcb_cr3 = KPML4phys;
  	thread0.td_frame = &proc0_tf;
  
@@ -1158,10 +1224,91 @@ index 0890c1b0..52bcfb26 100644
          env = getenv("kernelname");
  	if (env != NULL)
  		strlcpy(kernelname, env, sizeof(kernelname));
-@@ -2397,6 +2619,254 @@ user_dbreg_trap(void)
+@@ -2397,6 +2647,342 @@ user_dbreg_trap(void)
          return 0;
  }
  
++/**
++* missing part 1 compared to cpu_switch.S.
++*/
++static inline void sva_missing_part1_set_pcb_flag(struct thread *old){
++
++	/* movq	TD_PCB(%rdi),%r8 
++	orl	$PCB_FULL_IRET,PCB_FLAGS(%r8)  //  : full iret is set to 1
++	*/
++	old->td_pcb->pcb_flags |= PCB_FULL_IRET;
++
++}
++
++
++/* loading the new thread: 
++* At this point, we've switched address spaces and are ready
++* to load up the rest of the next context.
++*/
++static inline void sva_missing_part2_load_new_thr(struct thread *new){
++
++	/* Skip loading user fsbase/gsbase for kthreads 
++	testl	$TDP_KTHREAD,TD_PFLAGS(%rsi)  /* src/sys/sys/proc.h:426:#define	TDP_KTHREAD	0x00200000 // This is an official kernel thread 
++	jnz	do_kthread
++	*/
++	if ((new->td_pflags & TDP_KTHREAD) == 0){
++		// loading user fsbase/gsbase for user threads
++        if (new->td_proc->p_md.md_ldt != 0 ){
++			// do_ldt
++			set_user_ldt(&new->td_proc->p_md);
++
++	    }else{
++			lldt(0);
++	    }
++
++	    /* Restore fs base in GDT  */
++
++		uint64_t fsbse64__ = new->td_pcb->pcb_fsbase; 
++		unsigned int fsbse_low_ = (unsigned int)new->td_pcb->pcb_fsbase; 
++		struct user_segment_descriptor * pc_fs32p__ = PCPU_GET(fs32p);
++
++		USD_SETBASE(pc_fs32p__, fsbse_low_);
++
++		uint64_t pc_fs32p_int64;
++		memcpy(&pc_fs32p_int64, pc_fs32p__, sizeof(struct user_segment_descriptor));
++
++	}
++	 /* do_kthread: */
++	 struct amd64tss *pc_tssp_rax__ = PCPU_GET(tssp);
++
++	 struct amd64tss *pcb_tssp_rdx__ = new->td_pcb->pcb_tssp;
++	 if ( pcb_tssp_rdx__ == 0){
++	 	pcb_tssp_rdx__ = PCPU_GET(commontssp);
++	 }
++
++	 if ( pc_tssp_rax__ != pcb_tssp_rdx__){
++	 	// do_tss
++
++	 	PCPU_SET(tssp, pcb_tssp_rdx__);
++
++	 	struct system_segment_descriptor *pc_tss_rax__ = PCPU_GET(tss);
++
++		pc_tss_rax__->sd_lobase = (u_long)pcb_tssp_rdx__ & 0xffffff;
++		pc_tss_rax__->sd_hibase = ((u_long)pcb_tssp_rdx__ >> 24) & 0xfffffffffful;
++		pc_tss_rax__->sd_type = SDT_SYSTSS;
++		pc_tss_rax__->sd_p = 1;
++		ltr(GSEL(GPROC0_SEL, SEL_KPL));
++
++	 }
++
++	 /* done_tss: */
++	 PCPU_SET(rsp0, new->td_pcb);
++	 PCPU_SET(curpcb, new->td_pcb);
++	 //new->td_pcb->pcb_tssp->tss_rsp0 = new->td_pcb; // spin lock too long/stuck here
++	 //pcb_tssp_rdx__->tss_rsp0 = new->td_pcb; // masked for geom trap 14 in kernel
++
++	 /**
++	  * DONE missing part 2.
++	  * The last statement movq %rsi,PCPU(CURTHREAD) is done in original SVA immediately after this function 
++	  */
++
++}
++
 +/*
 + * Function: cpu_switch_sva()
 + *
@@ -1193,6 +1340,9 @@ index 0890c1b0..52bcfb26 100644
 +   * Use SVA to context switch from the old thread to the new thread.
 +   */
 +  if (new->sva) {
++
++	sva_missing_part1_set_pcb_flag(old);
++
 +    /*
 +     * Mark that the old process is about to have SVA state saved for it.
 +     */
@@ -1254,6 +1404,8 @@ index 0890c1b0..52bcfb26 100644
 +    }
 +    printf ("SVA: SMP Swap End\n");
 +#endif
++
++	sva_missing_part2_load_new_thr(new);
 +
 +    /*
 +     * Update the FreeBSD per-cpu data structure to know which thread is
@@ -1379,6 +1531,8 @@ index 0890c1b0..52bcfb26 100644
 +    }
 +    printf ("SVA: SMP Swap End\n");
 +#endif
++
++	sva_missing_part2_load_new_thr(new);
 +
 +    /*
 +     * Update the FreeBSD per-cpu data structure to know which thread is
@@ -3370,259 +3524,6 @@ index 2f737758..27b571c2 100644
  	movl	$EFAULT,%eax
 -	ret
 +	RETQ
-diff --git a/sys/amd64/amd64/sva_support.c b/sys/amd64/amd64/sva_support.c
-new file mode 100644
-index 00000000..ed8ff1dc
---- /dev/null
-+++ b/sys/amd64/amd64/sva_support.c
-@@ -0,0 +1,247 @@
-+#include <sys/cdefs.h>
-+#include <sys/param.h>
-+#include <sys/systm.h>
-+#include <sys/pcpu.h>
-+
-+#include <vm/vm.h>
-+#include <vm/pmap.h>
-+
-+#include <machine/vmparam.h>
-+#include <machine/pcb.h>
-+
-+/*
-+ * Prototypes for the real functions.
-+ */
-+extern int real_copyin(const void * __restrict udaddr, void * __restrict kaddr, size_t len) __nonnull(1) __nonnull(2);
-+
-+extern int real_copyout(const void * __restrict kaddr, void * __restrict udaddr, size_t len) __nonnull(1) __nonnull(2);
-+
-+extern long	real_fuword(const void *base);
-+extern int	real_fubyte(const void *base);
-+extern int	real_fuword16(void *base);
-+extern int32_t	real_fuword32(const void *base);
-+extern int64_t	real_fuword64(const void *base);
-+
-+extern int real_subyte(void *base, int byte);
-+extern int real_suword(void *base, long word);
-+extern int real_suword16(void *base, int word);
-+extern int real_suword32(void *base, int32_t word);
-+extern int real_suword64(void *base, int64_t word);
-+
-+extern uint32_t real_casuword32(volatile uint32_t *base, uint32_t oldval, uint32_t newval);
-+extern u_long	 real_casuword(volatile u_long *p, u_long oldval, u_long newval);
-+
-+/*
-+ * Implementations of the functions that use the SVA-OS intrinsics.
-+ */
-+int
-+copyinstr(const void * __restrict udaddr, void * __restrict kaddr,
-+	        size_t len, size_t * __restrict lencopied) {
-+  /* Number of bytes copied */
-+  uintptr_t copySize;
-+
-+  /*
-+   * Ensure that the copy won't read in kernel-space memory for the string.
-+   */
-+  if (VM_MAXUSER_ADDRESS <= udaddr)
-+    return EFAULT;
-+
-+  if (len >= (VM_MAXUSER_ADDRESS - (uintptr_t)udaddr))
-+    len = (VM_MAXUSER_ADDRESS - (uintptr_t)udaddr);
-+
-+  /*
-+   * Note that we want to use SVA to unwind the stack if we hit a fault.
-+   */
-+  PCPU_GET(curpcb)->pcb_onfault = 1;
-+
-+  /*
-+   * Perform the copy.
-+   */
-+  copySize = sva_invokestrncpy (kaddr, udaddr, len);
-+
-+  /*
-+   * Note that we aren't expecting a fault now.
-+   */
-+  PCPU_GET(curpcb)->pcb_onfault = 0;
-+
-+  /*
-+   * Determine if the string name is too long or if we hit a fault.
-+   */
-+  if (copySize == -1)
-+    return EFAULT;
-+
-+  if (copySize == len)
-+    return ENAMETOOLONG;
-+
-+  /*
-+   * Report the number of bytes copied to the caller.
-+   */
-+  if (lencopied)
-+    *lencopied = copySize + 1;
-+  return 0;
-+}
-+
-+int
-+copyin(const void * __restrict udaddr,
-+       void * __restrict kaddr,
-+	    size_t len) {
-+  uintptr_t retval;
-+  if (sva_invoke (udaddr, kaddr, len, &retval, real_copyin)) {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return EFAULT;
-+  } else {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return (int)(retval);
-+  }
-+}
-+
-+int
-+copyout(const void * __restrict kaddr,
-+        void * __restrict udaddr,
-+        size_t len) {
-+  uintptr_t retval;
-+  if (sva_invoke (kaddr, udaddr, len, &retval, real_copyout)) {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return EFAULT;
-+  } else {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return (int)(retval);
-+  }
-+}
-+
-+int64_t
-+fuword64 (const void * addr) {
-+  uintptr_t retval;
-+  if (sva_invoke (addr, 0, 0, &retval, real_fuword64)) {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return -1;
-+  } else {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return (int64_t)(retval);
-+  }
-+}
-+
-+int64_t
-+fuword (const void * addr) {
-+  return fuword64 (addr);
-+}
-+
-+int32_t
-+fuword32 (const void * addr) {
-+  uintptr_t retval;
-+  if (sva_invoke (addr, 0, 0, &retval, real_fuword32)) {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return -1;
-+  } else {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return (int32_t)(retval);
-+  }
-+}
-+
-+int
-+fuword16 (void * addr) {
-+  uintptr_t retval;
-+  if (sva_invoke (addr, 0, 0, &retval, real_fuword16)) {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return -1;
-+  } else {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return (int)(retval);
-+  }
-+}
-+
-+int
-+fubyte (const void * addr) {
-+  uintptr_t retval;
-+  if (sva_invoke (addr, 0, 0, &retval, real_fubyte)) {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return -1;
-+  } else {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return (int)(retval);
-+  }
-+}
-+
-+int
-+subyte(void *base, int byte) {
-+  uintptr_t retval;
-+  if (sva_invoke (base, byte, 0, &retval, real_subyte)) {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return -1;
-+  } else {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return (int)(retval);
-+  }
-+}
-+
-+int
-+suword(void *base, long word) {
-+  uintptr_t retval;
-+  if (sva_invoke (base, word, 0, &retval, real_suword)) {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return -1;
-+  } else {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return (int)(retval);
-+  }
-+}
-+
-+int
-+suword16(void *base, int word) {
-+  uintptr_t retval;
-+  if (sva_invoke (base, word, 0, &retval, real_suword16)) {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return -1;
-+  } else {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return (int)(retval);
-+  }
-+}
-+
-+int
-+suword32(void *base, int32_t word) {
-+  uintptr_t retval;
-+  if (sva_invoke (base, word, 0, &retval, real_suword32)) {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return -1;
-+  } else {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return (int)(retval);
-+  }
-+}
-+
-+int
-+suword64(void *base, int64_t word) {
-+  uintptr_t retval;
-+  if (sva_invoke (base, word, 0, &retval, real_suword64)) {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return -1;
-+  } else {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return (int)(retval);
-+  }
-+}
-+
-+uint32_t
-+casuword32 (volatile uint32_t *base, uint32_t oldval, uint32_t newval) {
-+  uintptr_t retval;
-+  if (sva_invoke (base, oldval, newval, &retval, real_casuword32)) {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return -1;
-+  } else {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return (int)(retval);
-+  }
-+}
-+
-+u_long
-+casuword(volatile u_long *p, u_long oldval, u_long newval) {
-+  uintptr_t retval;
-+  if (sva_invoke (p, oldval, newval, &retval, real_casuword)) {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return -1;
-+  } else {
-+    PCPU_GET(curpcb)->pcb_onfault = 0;
-+    return (int)(retval);
-+  }
-+}
 diff --git a/sys/amd64/amd64/sys_machdep.c b/sys/amd64/amd64/sys_machdep.c
 index 743a1200..519f6ec5 100644
 --- a/sys/amd64/amd64/sys_machdep.c
@@ -3637,7 +3538,7 @@ index 743a1200..519f6ec5 100644
  	 * XXX
  	 * While this is restricted to root, we should probably figure out
 diff --git a/sys/amd64/amd64/trap.c b/sys/amd64/amd64/trap.c
-index f3db837e..af0769c3 100644
+index f3db837e..852510f2 100644
 --- a/sys/amd64/amd64/trap.c
 +++ b/sys/amd64/amd64/trap.c
 @@ -123,6 +123,9 @@ extern void syscall(struct trapframe *frame);
@@ -3650,19 +3551,17 @@ index f3db837e..af0769c3 100644
  static void trap_fatal(struct trapframe *, vm_offset_t);
  
  #define MAX_TRAP_MSG		33
-@@ -164,28 +167,489 @@ static char *trap_msg[] = {
- };
- 
- #ifdef KDB
--static int kdb_on_nmi = 1;
--SYSCTL_INT(_machdep, OID_AUTO, kdb_on_nmi, CTLFLAG_RW,
--	&kdb_on_nmi, 0, "Go to KDB on NMI");
--TUNABLE_INT("machdep.kdb_on_nmi", &kdb_on_nmi);
-+static int kdb_on_nmi = 1;
-+SYSCTL_INT(_machdep, OID_AUTO, kdb_on_nmi, CTLFLAG_RW,
-+	&kdb_on_nmi, 0, "Go to KDB on NMI");
-+TUNABLE_INT("machdep.kdb_on_nmi", &kdb_on_nmi);
-+#endif
+@@ -169,23 +172,484 @@ SYSCTL_INT(_machdep, OID_AUTO, kdb_on_nmi, CTLFLAG_RW,
+ 	&kdb_on_nmi, 0, "Go to KDB on NMI");
+ TUNABLE_INT("machdep.kdb_on_nmi", &kdb_on_nmi);
+ #endif
+-static int panic_on_nmi = 1;
+-SYSCTL_INT(_machdep, OID_AUTO, panic_on_nmi, CTLFLAG_RW,
+-	&panic_on_nmi, 0, "Panic on NMI");
+-TUNABLE_INT("machdep.panic_on_nmi", &panic_on_nmi);
+-static int prot_fault_translation = 0;
+-SYSCTL_INT(_machdep, OID_AUTO, prot_fault_translation, CTLFLAG_RW,
+-	&prot_fault_translation, 0, "Select signal to deliver on protection fault");
 +static int panic_on_nmi = 1;
 +SYSCTL_INT(_machdep, OID_AUTO, panic_on_nmi, CTLFLAG_RW,
 +	&panic_on_nmi, 0, "Panic on NMI");
@@ -4088,14 +3987,7 @@ index f3db837e..af0769c3 100644
 +#ifdef KDB
 +			if (kdb_trap(type, 0, frame))
 +				goto out;
- #endif
--static int panic_on_nmi = 1;
--SYSCTL_INT(_machdep, OID_AUTO, panic_on_nmi, CTLFLAG_RW,
--	&panic_on_nmi, 0, "Panic on NMI");
--TUNABLE_INT("machdep.panic_on_nmi", &panic_on_nmi);
--static int prot_fault_translation = 0;
--SYSCTL_INT(_machdep, OID_AUTO, prot_fault_translation, CTLFLAG_RW,
--	&prot_fault_translation, 0, "Select signal to deliver on protection fault");
++#endif
 +			break;
  
 -/*
@@ -4488,7 +4380,7 @@ index f3db837e..af0769c3 100644
  static void
  trap_fatal(frame, eva)
  	struct trapframe *frame;
-@@ -911,6 +1638,83 @@ amd64_syscall(struct thread *td, int traced)
+@@ -911,6 +1638,167 @@ amd64_syscall(struct thread *td, int traced)
  	int error;
  	ksiginfo_t ksi;
  
@@ -4528,6 +4420,81 @@ index f3db837e..af0769c3 100644
 +	syscallret(td, error, &sa);
 +}
 +
++/**
++ * missing part syscall-04: doreti in exception.S
++*/
++
++static inline void sva_missing_full_restore_3f(struct thread *td){
++	if (td != curthread){
++		panic("Lele: td is expected to be curthread\n");
++	}
++
++	if (td->td_frame->tf_cs & 0xff & SEL_RPL_MASK){
++
++		/* doreti_ast: */
++		disable_intr();
++		while (td->td_flags & (TDF_ASTPENDING | TDF_NEEDRESCHED)){
++				// enable_intr();
++				ast (td->td_frame); // will enable intr in ast()
++				disable_intr();
++				// BUFFER_WRITE("done ast; now go back to check ast again\n");
++		}
++	}
++  	/* doreti_exit: */
++	/*
++		* Do not reload segment registers for kernel.
++		* Since we do not reload segments registers with sane
++		* values on kernel entry, descriptors referenced by
++		* segments registers might be not valid.  This is fatal
++		* for user mode, but is not a problem for the kernel.
++		*/
++	struct pcb *curpcb_ = PCPU_GET(curpcb);
++	
++	/* testb	$SEL_RPL_MASK,TF_CS(%rsp) 
++	   jz	ld_regs*/
++	if ((SEL_RPL_MASK & td->td_frame->tf_cs & 0xff ) && 
++	/* testl	$PCB_FULL_IRET,PCB_FLAGS(%r8) 
++	   jz	ld_regs*/
++	// (td->td_pcb->pcb_flags & PCB_FULL_IRET & 0xffffffff)
++	(curpcb_->pcb_flags & PCB_FULL_IRET & 0xffffffff) ){  
++		/*
++		testl	$TF_HASSEGS,TF_FLAGS(%rsp)
++		je	set_segs
++		*/
++		if (!(td->td_frame->tf_flags & TF_HASSEGS)){
++			td->td_frame->tf_fs = GSEL(GUFS32_SEL, SEL_UPL);
++		}
++
++		/*
++		do_segs:
++			// Restore %fs and fsbase 
++			movw	TF_FS(%rsp),%ax
++			.globl	ld_fs
++		ld_fs:
++			movw	%ax,%fs
++			cmpw	$KUF32SEL,%ax
++			jne	1f
++			movl	$MSR_FSBASE,%ecx
++			movl	PCB_FSBASE(%r8),%eax
++			movl	PCB_FSBASE+4(%r8),%edx
++			.globl	ld_fsbase
++		ld_fsbase:
++			wrmsr
++		*/
++
++		load_fs(td->td_frame->tf_fs);
++
++      	if (td->td_frame->tf_fs == GSEL(GUFS32_SEL, SEL_UPL)){
++			wrmsr(MSR_FSBASE, curpcb_->pcb_fsbase);
++		}
++
++	}else{
++		  // ld_regs
++		  /* Those should be already done in SVA */
++	}
++
++}
++
 +#if 1
 +/*
 + *	syscall -	system call request C handler
@@ -4554,6 +4521,9 @@ index f3db837e..af0769c3 100644
 +  td = curthread;
 +  traced = 0;
 +
++  /* missing part syscall-01: reset td_pcb->pcb_flags */
++  td->td_pcb->pcb_flags &= (~PCB_FULL_IRET & 0xffffffff);
++  
 +  /*
 +   * Install a trap frame into the thread structure.
 +   */
@@ -4565,6 +4535,12 @@ index f3db837e..af0769c3 100644
 +	 */
 +	extern void sva_syscall_trapframe (struct trapframe * tf);
 +	sva_syscall_trapframe (&localframe);
++
++	/* Lele: missing part 02: 
++		movl	$TF_HASSEGS,TF_FLAGS(%rsp)
++	*/
++	td->td_frame->tf_flags &= TF_HASSEGS;
++
 +#if 0
 +  traced = localframe.tf_rflags & PSL_T;
 +#endif
@@ -4572,20 +4548,62 @@ index f3db837e..af0769c3 100644
  #ifdef DIAGNOSTIC
  	if (ISPL(td->td_frame->tf_cs) != SEL_UPL) {
  		panic("syscall");
-@@ -939,4 +1743,11 @@ amd64_syscall(struct thread *td, int traced)
+@@ -939,4 +1827,53 @@ amd64_syscall(struct thread *td, int traced)
  	     syscallname(td->td_proc, sa.code)));
  
  	syscallret(td, error, &sa);
 +
++  /**
++   * missing part 03
++   1:	movq	PCPU(CURPCB),%rax
++	// Disable interrupts before testing PCB_FULL_IRET. 
++    cli
++	testl	$PCB_FULL_IRET,PCB_FLAGS(%rax)
++	jnz	3f
++	// Check for and handle AST's on return to userland. 
++	movq	PCPU(CURTHREAD),%rax
++	testl	$TDF_ASTPENDING | TDF_NEEDRESCHED,TD_FLAGS(%rax)
++	jne	2f
++	// Restore preserved registers. 
++	MEXITCOUNT
++
++  */
++begin_1f:
++	
++	disable_intr();
++
++	if(td->td_pcb->pcb_flags & PCB_FULL_IRET) {
++	goto full_restore_reti_3f;  // 3f
++	}else{
++	//handle ast 
++	goto ast_2f;
++	}
++
++ast_2f:
++
 +#if 1
 +  /* SVA: The SVA assembly code does not run the AST */
-+  if (curthread->td_flags & (TDF_ASTPENDING | TDF_NEEDRESCHED))
++  if (curthread->td_flags & (TDF_ASTPENDING | TDF_NEEDRESCHED)){
++	enable_intr();
 +    ast (&localframe);
++	goto begin_1f;
++  }else{
++	 //no full iret, no ast, now exit
++	  goto out__;
++  }
 +#endif
++
++full_restore_reti_3f:
++
++	sva_missing_full_restore_3f(td);
++	
++out__:
++	enable_intr(); //just in case intr got masked in sva_missing_full_restore_3f
++
  }
 +#endif
 diff --git a/sys/amd64/amd64/vm_machdep.c b/sys/amd64/amd64/vm_machdep.c
-index c0be7202..10107ff7 100644
+index c0be7202..d844c736 100644
 --- a/sys/amd64/amd64/vm_machdep.c
 +++ b/sys/amd64/amd64/vm_machdep.c
 @@ -83,6 +83,10 @@ __FBSDID("$FreeBSD: release/9.0.0/sys/amd64/amd64/vm_machdep.c 223758 2011-07-04
@@ -4599,10 +4617,79 @@ index c0be7202..10107ff7 100644
  static void	cpu_reset_real(void);
  #ifdef SMP
  static void	cpu_reset_proxy(void);
-@@ -90,6 +94,22 @@ static u_int	cpu_reset_proxyid;
+@@ -90,6 +94,96 @@ static u_int	cpu_reset_proxyid;
  static volatile u_int	cpu_reset_proxy_active;
  #endif
  
++/**
++ * missing part syscall-04: doreti
++*/
++static inline void sva_missing_thr_new_full_restore_3f(struct thread *td){
++  if (td != curthread){
++	  panic("Lele: td is expected to be curthread\n");
++  }
++
++  if (td->td_frame->tf_cs & 0xff & SEL_RPL_MASK){
++
++		/* doreti_ast: */
++		disable_intr();
++		while (td->td_flags & (TDF_ASTPENDING | TDF_NEEDRESCHED)){
++			ast (td->td_frame);
++			disable_intr();
++		}
++	}
++	/* doreti_exit: */
++	struct pcb *curpcb_ = PCPU_GET(curpcb);
++	
++	/* testb	$SEL_RPL_MASK,TF_CS(%rsp) 
++	   jz	ld_regs*/
++	if ((SEL_RPL_MASK & td->td_frame->tf_cs & 0xff ) && 
++	/* testl	$PCB_FULL_IRET,PCB_FLAGS(%r8) 
++	   jz	ld_regs*/
++	(td->td_pcb->pcb_flags & PCB_FULL_IRET & 0xffffffff) ){  
++		/*
++		testl	$TF_HASSEGS,TF_FLAGS(%rsp)
++		je	set_segs
++		*/
++		if (!(td->td_frame->tf_flags & TF_HASSEGS)){
++			/* set_segs: */
++		    // td->td_frame->tf_ds = GSEL(GUDATA_SEL, SEL_UPL);
++		    // td->td_frame->tf_es = GSEL(GUDATA_SEL, SEL_UPL);
++			td->td_frame->tf_fs = GSEL(GUFS32_SEL, SEL_UPL);
++			// td->td_frame->tf_gs = GSEL(GUGS32_SEL, SEL_UPL);
++		}
++
++		/*			
++		do_segs:
++			// Restore %fs and fsbase 
++			movw	TF_FS(%rsp),%ax
++			.globl	ld_fs
++		ld_fs:
++			movw	%ax,%fs
++			cmpw	$KUF32SEL,%ax
++			jne	1f
++			movl	$MSR_FSBASE,%ecx
++			movl	PCB_FSBASE(%r8),%eax
++			movl	PCB_FSBASE+4(%r8),%edx
++			.globl	ld_fsbase
++		ld_fsbase:
++			wrmsr
++		*/
++		load_fs(td->td_frame->tf_fs);
++	    if (td->td_frame->tf_fs == GSEL(GUFS32_SEL, SEL_UPL)){
++
++			wrmsr(MSR_FSBASE, td->td_pcb->pcb_fsbase);
++		
++		}
++		
++	}else{
++		  // ld_regs
++		  /* Those are done in SVA */
++	}
++
++}
++
++
 +#if 1
 +void
 +kernel_thread_trampoline (struct thread * td)
@@ -4611,6 +4698,11 @@ index c0be7202..10107ff7 100644
 +                        void *arg,
 +                        struct trapframe *frame);
 +
++#if defined (TLS_PATCH_THR_NEW) // Lele: disable this patch since multi-threading library is not supported yet
++
++	sva_missing_thr_new_full_restore_3f(td);
++
++#endif // TRACK_HELLO && TRACK_HELLLO_THR_NEW
 +  /*
 +   * Call the specified function.
 +   */
@@ -4622,7 +4714,7 @@ index c0be7202..10107ff7 100644
  /*
   * Finish a fork operation, with process p2 nearly set up.
   * Copy and update the pcb, set up the stack so that the child
-@@ -216,6 +236,27 @@ cpu_fork(td1, p2, td2, flags)
+@@ -216,6 +310,27 @@ cpu_fork(td1, p2, td2, flags)
  		mdp2->md_ldt = NULL;
  	mtx_unlock(&dt_lock);
  
@@ -4650,7 +4742,7 @@ index c0be7202..10107ff7 100644
  	/*
  	 * Now, cpu_switch() can schedule the new process.
  	 * pcb_rsp is loaded pointing to the cpu_switch() stack frame
-@@ -245,6 +286,10 @@ cpu_set_fork_handler(td, func, arg)
+@@ -245,6 +360,10 @@ cpu_set_fork_handler(td, func, arg)
  	 */
  	td->td_pcb->pcb_r12 = (long) func;	/* function */
  	td->td_pcb->pcb_rbx = (long) arg;	/* first arg */
@@ -4661,7 +4753,7 @@ index c0be7202..10107ff7 100644
  }
  
  void
-@@ -259,6 +304,13 @@ cpu_exit(struct thread *td)
+@@ -259,6 +378,13 @@ cpu_exit(struct thread *td)
  		user_ldt_free(td);
  	else
  		mtx_unlock(&dt_lock);
@@ -4675,7 +4767,7 @@ index c0be7202..10107ff7 100644
  }
  
  void
-@@ -327,12 +379,15 @@ cpu_thread_free(struct thread *td)
+@@ -327,12 +453,15 @@ cpu_thread_free(struct thread *td)
  void
  cpu_set_syscall_retval(struct thread *td, int error)
  {
@@ -4692,7 +4784,7 @@ index c0be7202..10107ff7 100644
  		break;
  
  	case ERESTART:
-@@ -345,8 +400,13 @@ cpu_set_syscall_retval(struct thread *td, int error)
+@@ -345,8 +474,13 @@ cpu_set_syscall_retval(struct thread *td, int error)
  		 * %r10 restore is only required for freebsd/amd64 processes,
  		 * but shall be innocent for any ia32 ABI.
  		 */
@@ -4706,7 +4798,7 @@ index c0be7202..10107ff7 100644
  		break;
  
  	case EJUSTRETURN:
-@@ -359,8 +419,12 @@ cpu_set_syscall_retval(struct thread *td, int error)
+@@ -359,8 +493,12 @@ cpu_set_syscall_retval(struct thread *td, int error)
  			else
  				error = td->td_proc->p_sysent->sv_errtbl[error];
  		}
@@ -4719,7 +4811,7 @@ index c0be7202..10107ff7 100644
  		break;
  	}
  }
-@@ -424,7 +488,108 @@ cpu_set_upcall(struct thread *td, struct thread *td0)
+@@ -424,7 +562,121 @@ cpu_set_upcall(struct thread *td, struct thread *td0)
  	/* Setup to release spin count in fork_exit(). */
  	td->td_md.md_spinlock_count = 1;
  	td->td_md.md_saved_flags = PSL_KERNEL | PSL_I;
@@ -4733,6 +4825,19 @@ index c0be7202..10107ff7 100644
 +  td->sva = 1;
 +  td->callout = fork_return;
 +  td->callarg = td;
++
++  /* Lele: this will affect how thr_new behaves. Original kernel
++	set fork_trampoline as starting address for new thread upon scheduled. It calls fork_exit and then doreti for syscall return.
++
++	However, the sva_init_stack would make the starting address of new thread
++	as kernel_thread_trampoline, and use 'sc_ret' for syscall return.
++
++	However, 'sc_ret' has missing part compared to doreti in terms of FSBASE restore for CPU. Therefore, we need either: 
++		1) update sc_ret to support FSBASE restore by adding fsbase to integer state.
++	or
++		2) hacking kernel_thread_trampoline. as shown above in sva_missing_thr_new_full_restore_3f
++
++   */
 +  td->svaID = sva_init_stack (td->td_kstack,
 +	                            stacklen,
 +	                            kernel_thread_trampoline,
@@ -4828,712 +4933,6 @@ index c0be7202..10107ff7 100644
  
  /*
   * Set that machine state for performing an upcall that has to
-diff --git a/sys/amd64/conf/SVA b/sys/amd64/conf/SVA
-new file mode 100644
-index 00000000..aeb23998
---- /dev/null
-+++ b/sys/amd64/conf/SVA
-@@ -0,0 +1,352 @@
-+#
-+# GENERIC -- Generic kernel configuration file for FreeBSD/amd64
-+#
-+# For more information on this file, please read the config(5) manual page,
-+# and/or the handbook section on Kernel Configuration Files:
-+#
-+#    http://www.FreeBSD.org/doc/en_US.ISO8859-1/books/handbook/kernelconfig-config.html
-+#
-+# The handbook is also available locally in /usr/share/doc/handbook
-+# if you've installed the doc distribution, otherwise always see the
-+# FreeBSD World Wide Web server (http://www.FreeBSD.org/) for the
-+# latest information.
-+#
-+# An exhaustive list of options and more detailed explanations of the
-+# device lines is also present in the ../../conf/NOTES and NOTES files.
-+# If you are in doubt as to the purpose or necessity of a line, check first
-+# in NOTES.
-+#
-+# $FreeBSD: release/9.0.0/sys/amd64/conf/GENERIC 227305 2011-11-07 13:40:54Z marius $
-+
-+cpu		HAMMER
-+ident		GENERIC
-+
-+#makeoptions	DEBUG=-g		# Build kernel with gdb(1) debug symbols
-+
-+#******************
-+# SVA Related Flags
-+#******************
-+options     SVA_MMU
-+
-+options 	SCHED_ULE		# ULE scheduler
-+#options   SCHED_4BSD
-+options 	PREEMPTION		# Enable kernel thread preemption
-+options 	INET			# InterNETworking
-+options 	INET6			# IPv6 communications protocols
-+options 	SCTP			# Stream Control Transmission Protocol
-+options 	FFS			# Berkeley Fast Filesystem
-+options 	SOFTUPDATES		# Enable FFS soft updates support
-+options 	UFS_ACL			# Support for access control lists
-+options 	UFS_DIRHASH		# Improve performance on big directories
-+options 	UFS_GJOURNAL		# Enable gjournal-based UFS journaling
-+options 	MD_ROOT			# MD is a potential root device
-+options 	NFSCL			# New Network Filesystem Client
-+options 	NFSD			# New Network Filesystem Server
-+options 	NFSLOCKD		# Network Lock Manager
-+options 	NFS_ROOT		# NFS usable as /, requires NFSCL
-+options 	MSDOSFS			# MSDOS Filesystem
-+options 	CD9660			# ISO 9660 Filesystem
-+options 	PROCFS			# Process filesystem (requires PSEUDOFS)
-+options 	PSEUDOFS		# Pseudo-filesystem framework
-+options 	GEOM_PART_GPT		# GUID Partition Tables.
-+options 	GEOM_LABEL		# Provides labelization
-+options 	COMPAT_FREEBSD32	# Compatible with i386 binaries
-+options 	COMPAT_FREEBSD4		# Compatible with FreeBSD4
-+options 	COMPAT_FREEBSD5		# Compatible with FreeBSD5
-+options 	COMPAT_FREEBSD6		# Compatible with FreeBSD6
-+options 	COMPAT_FREEBSD7		# Compatible with FreeBSD7
-+options 	SCSI_DELAY=5000		# Delay (in ms) before probing SCSI
-+options 	KTRACE			# ktrace(1) support
-+options 	STACK			# stack(9) support
-+options 	SYSVSHM			# SYSV-style shared memory
-+options 	SYSVMSG			# SYSV-style message queues
-+options 	SYSVSEM			# SYSV-style semaphores
-+options 	_KPOSIX_PRIORITY_SCHEDULING # POSIX P1003_1B real-time extensions
-+options 	PRINTF_BUFR_SIZE=128	# Prevent printf output being interspersed.
-+options 	KBD_INSTALL_CDEV	# install a CDEV entry in /dev
-+options 	HWPMC_HOOKS		# Necessary kernel hooks for hwpmc(4)
-+options 	AUDIT			# Security event auditing
-+options 	MAC			# TrustedBSD MAC Framework
-+#options 	KDTRACE_FRAME		# Ensure frames are compiled in
-+#options 	KDTRACE_HOOKS		# Kernel DTrace hooks
-+options 	INCLUDE_CONFIG_FILE     # Include this file in kernel
-+options 	KDB			# Kernel debugger related code
-+#options 	KDB_TRACE		# Print a stack trace for a panic
-+options		DDB
-+options		BREAK_TO_DEBUGGER # Break signal on console goes into debugger
-+options		ALT_BREAK_TO_DEBUGGER # Break signal on console goes into debugger
-+
-+# JTC: lock debugging stuff
-+#options WITNESS
-+#options WITNESS_KDB
-+#options WITNESS_SKIPSPIN
-+
-+# Make an SMP-capable kernel by default
-+#options 	SMP			# Symmetric MultiProcessor Kernel
-+
-+# CPU frequency control
-+#device		cpufreq
-+
-+# Bus support.
-+device		acpi
-+device		pci
-+
-+# Floppy drives
-+device		fdc
-+
-+# ATA controllers
-+device		ahci		# AHCI-compatible SATA controllers
-+device		ata		# Legacy ATA/SATA controllers
-+options 	ATA_CAM		# Handle legacy controllers with CAM
-+options 	ATA_STATIC_ID	# Static device numbering
-+device		mvs		# Marvell 88SX50XX/88SX60XX/88SX70XX/SoC SATA
-+device		siis		# SiliconImage SiI3124/SiI3132/SiI3531 SATA
-+
-+# SCSI Controllers
-+device		ahc		# AHA2940 and onboard AIC7xxx devices
-+options 	AHC_REG_PRETTY_PRINT	# Print register bitfields in debug
-+					# output.  Adds ~128k to driver.
-+device		ahd		# AHA39320/29320 and onboard AIC79xx devices
-+options 	AHD_REG_PRETTY_PRINT	# Print register bitfields in debug
-+					# output.  Adds ~215k to driver.
-+device		esp		# AMD Am53C974 (Tekram DC-390(T))
-+device		hptiop		# Highpoint RocketRaid 3xxx series
-+device		isp		# Qlogic family
-+#device		ispfw		# Firmware for QLogic HBAs- normally a module
-+device		mpt		# LSI-Logic MPT-Fusion
-+device		mps		# LSI-Logic MPT-Fusion 2
-+#device		ncr		# NCR/Symbios Logic
-+device		sym		# NCR/Symbios Logic (newer chipsets + those of `ncr')
-+device		trm		# Tekram DC395U/UW/F DC315U adapters
-+
-+device		adv		# Advansys SCSI adapters
-+device		adw		# Advansys wide SCSI adapters
-+device		aic		# Adaptec 15[012]x SCSI adapters, AIC-6[23]60.
-+device		bt		# Buslogic/Mylex MultiMaster SCSI adapters
-+
-+# ATA/SCSI peripherals
-+device		scbus		# SCSI bus (required for ATA/SCSI)
-+device		ch		# SCSI media changers
-+device		da		# Direct Access (disks)
-+device		sa		# Sequential Access (tape etc)
-+device		cd		# CD
-+device		pass		# Passthrough device (direct ATA/SCSI access)
-+device		ses		# SCSI Environmental Services (and SAF-TE)
-+
-+# RAID controllers interfaced to the SCSI subsystem
-+#device		amr		# AMI MegaRAID
-+#device		arcmsr		# Areca SATA II RAID
-+#XXX it is not 64-bit clean, -scottl
-+#device		asr		# DPT SmartRAID V, VI and Adaptec SCSI RAID
-+#device		ciss		# Compaq Smart RAID 5*
-+#device		dpt		# DPT Smartcache III, IV - See NOTES for options
-+#device		hptmv		# Highpoint RocketRAID 182x
-+#device		hptrr		# Highpoint RocketRAID 17xx, 22xx, 23xx, 25xx
-+#device		iir		# Intel Integrated RAID
-+#device		ips		# IBM (Adaptec) ServeRAID
-+#device		mly		# Mylex AcceleRAID/eXtremeRAID
-+#device		twa		# 3ware 9000 series PATA/SATA RAID
-+
-+# RAID controllers
-+#device		aac		# Adaptec FSA RAID
-+#device		aacp		# SCSI passthrough for aac (requires CAM)
-+#device		ida		# Compaq Smart RAID
-+#device		mfi		# LSI MegaRAID SAS
-+#device		mlx		# Mylex DAC960 family
-+#XXX pointer/int warnings
-+#device		pst		# Promise Supertrak SX6000
-+#device		twe		# 3ware ATA RAID
-+#device		tws		# LSI 3ware 9750 SATA+SAS 6Gb/s RAID controller
-+
-+# atkbdc0 controls both the keyboard and the PS/2 mouse
-+device		atkbdc		# AT keyboard controller
-+device		atkbd		# AT keyboard
-+device		psm		# PS/2 mouse
-+
-+device		kbdmux		# keyboard multiplexer
-+
-+device		vga		# VGA video card driver
-+
-+device		splash		# Splash screen and screen saver support
-+
-+# syscons is the default console driver, resembling an SCO console
-+device		sc
-+options 	SC_PIXEL_MODE	# add support for the raster text mode
-+
-+device		agp		# support several AGP chipsets
-+
-+# PCCARD (PCMCIA) support
-+# PCMCIA and cardbus bridge support
-+#device		cbb		# cardbus (yenta) bridge
-+#device		pccard		# PC Card (16-bit) bus
-+#device		cardbus		# CardBus (32-bit) bus
-+
-+# Serial (COM) ports
-+device		uart		# Generic UART driver
-+
-+# Parallel port
-+#device		ppc
-+#device		ppbus		# Parallel port bus (required)
-+#device		lpt		# Printer
-+#device		plip		# TCP/IP over parallel
-+#device		ppi		# Parallel port interface device
-+#device		vpo		# Requires scbus and da
-+
-+device		puc		# Multi I/O cards and multi-channel UARTs
-+
-+# PCI Ethernet NICs.
-+device		bxe		# Broadcom BCM57710/BCM57711/BCM57711E 10Gb Ethernet
-+device		de		# DEC/Intel DC21x4x (``Tulip'')
-+device		em		# Intel PRO/1000 Gigabit Ethernet Family
-+device		igb		# Intel PRO/1000 PCIE Server Gigabit Family
-+device		ixgbe		# Intel PRO/10GbE PCIE Ethernet Family
-+device		le		# AMD Am7900 LANCE and Am79C9xx PCnet
-+device		ti		# Alteon Networks Tigon I/II gigabit Ethernet
-+device		txp		# 3Com 3cR990 (``Typhoon'')
-+device		vx		# 3Com 3c590, 3c595 (``Vortex'')
-+
-+# PCI Ethernet NICs that use the common MII bus controller code.
-+# NOTE: Be sure to keep the 'device miibus' line in order to use these NICs!
-+#device		miibus		# MII bus support
-+#device		ae		# Attansic/Atheros L2 FastEthernet
-+#device		age		# Attansic/Atheros L1 Gigabit Ethernet
-+#device		alc		# Atheros AR8131/AR8132 Ethernet
-+#device		ale		# Atheros AR8121/AR8113/AR8114 Ethernet
-+#device		bce		# Broadcom BCM5706/BCM5708 Gigabit Ethernet
-+#device		bfe		# Broadcom BCM440x 10/100 Ethernet
-+#device		bge		# Broadcom BCM570xx Gigabit Ethernet
-+#device		dc		# DEC/Intel 21143 and various workalikes
-+#device		et		# Agere ET1310 10/100/Gigabit Ethernet
-+#device		fxp		# Intel EtherExpress PRO/100B (82557, 82558)
-+#device		jme		# JMicron JMC250 Gigabit/JMC260 Fast Ethernet
-+#device		lge		# Level 1 LXT1001 gigabit Ethernet
-+#device		msk		# Marvell/SysKonnect Yukon II Gigabit Ethernet
-+#device		nfe		# nVidia nForce MCP on-board Ethernet
-+#device		nge		# NatSemi DP83820 gigabit Ethernet
-+#device		nve		# nVidia nForce MCP on-board Ethernet Networking
-+#device		pcn		# AMD Am79C97x PCI 10/100 (precedence over 'le')
-+#device		re		# RealTek 8139C+/8169/8169S/8110S
-+#device		rl		# RealTek 8129/8139
-+#device		sf		# Adaptec AIC-6915 (``Starfire'')
-+#device		sge		# Silicon Integrated Systems SiS190/191
-+#device		sis		# Silicon Integrated Systems SiS 900/SiS 7016
-+#device		sk		# SysKonnect SK-984x & SK-982x gigabit Ethernet
-+#device		ste		# Sundance ST201 (D-Link DFE-550TX)
-+#device		stge		# Sundance/Tamarack TC9021 gigabit Ethernet
-+#device		tl		# Texas Instruments ThunderLAN
-+#device		tx		# SMC EtherPower II (83c170 ``EPIC'')
-+#device		vge		# VIA VT612x gigabit Ethernet
-+#device		vr		# VIA Rhine, Rhine II
-+#device		wb		# Winbond W89C840F
-+#device		xl		# 3Com 3c90x (``Boomerang'', ``Cyclone'')
-+
-+# ISA Ethernet NICs.  pccard NICs included.
-+#device		cs		# Crystal Semiconductor CS89x0 NIC
-+# 'device ed' requires 'device miibus'
-+device		ed		# NE[12]000, SMC Ultra, 3c503, DS8390 cards
-+#device		ex		# Intel EtherExpress Pro/10 and Pro/10+
-+#device		ep		# Etherlink III based cards
-+#device		fe		# Fujitsu MB8696x based cards
-+#device		sn		# SMC's 9000 series of Ethernet chips
-+#device		xe		# Xircom pccard Ethernet
-+
-+# Wireless NIC cards
-+#device		wlan		# 802.11 support
-+#options 	IEEE80211_DEBUG	# enable debug msgs
-+#options 	IEEE80211_AMPDU_AGE # age frames in AMPDU reorder q's
-+#options 	IEEE80211_SUPPORT_MESH	# enable 802.11s draft support
-+#device		wlan_wep	# 802.11 WEP support
-+#device		wlan_ccmp	# 802.11 CCMP support
-+#device		wlan_tkip	# 802.11 TKIP support
-+#device		wlan_amrr	# AMRR transmit rate control algorithm
-+#device		an		# Aironet 4500/4800 802.11 wireless NICs.
-+#device		ath		# Atheros NIC's
-+#device		ath_pci		# Atheros pci/cardbus glue
-+#device		ath_hal		# pci/cardbus chip support
-+#options 	AH_SUPPORT_AR5416	# enable AR5416 tx/rx descriptors
-+#device		ath_rate_sample	# SampleRate tx rate control for ath
-+#device		bwi		# Broadcom BCM430x/BCM431x wireless NICs.
-+#device		bwn		# Broadcom BCM43xx wireless NICs.
-+#device		ipw		# Intel 2100 wireless NICs.
-+#device		iwi		# Intel 2200BG/2225BG/2915ABG wireless NICs.
-+#device		iwn		# Intel 4965/1000/5000/6000 wireless NICs.
-+#device		malo		# Marvell Libertas wireless NICs.
-+#device		mwl		# Marvell 88W8363 802.11n wireless NICs.
-+#device		ral		# Ralink Technology RT2500 wireless NICs.
-+#device		wi		# WaveLAN/Intersil/Symbol 802.11 wireless NICs.
-+#device		wpi		# Intel 3945ABG wireless NICs.
-+
-+# Pseudo devices.
-+device		loop		# Network loopback
-+device		random		# Entropy device
-+device		ether		# Ethernet support
-+device		vlan		# 802.1Q VLAN support
-+device		tun		# Packet tunnel.
-+device		pty		# BSD-style compatibility pseudo ttys
-+device		md		# Memory "disks"
-+device		gif		# IPv6 and IPv4 tunneling
-+device		faith		# IPv6-to-IPv4 relaying (translation)
-+device		firmware	# firmware assist module
-+
-+# The `bpf' device enables the Berkeley Packet Filter.
-+# Be aware of the administrative consequences of enabling this!
-+# Note that 'bpf' is required for DHCP.
-+device		bpf		# Berkeley packet filter
-+
-+# USB support
-+options 	USB_DEBUG	# enable debug msgs
-+device		uhci		# UHCI PCI->USB interface
-+device		ohci		# OHCI PCI->USB interface
-+device		ehci		# EHCI PCI->USB interface (USB 2.0)
-+device		xhci		# XHCI PCI->USB interface (USB 3.0)
-+device		usb		# USB Bus (required)
-+#device		udbp		# USB Double Bulk Pipe devices (needs netgraph)
-+device		uhid		# "Human Interface Devices"
-+device		ukbd		# Keyboard
-+#device		ulpt		# Printer
-+device		umass		# Disks/Mass storage - Requires scbus and da
-+device		ums		# Mouse
-+#device		urio		# Diamond Rio 500 MP3 player
-+# USB Serial devices
-+#device		u3g		# USB-based 3G modems (Option, Huawei, Sierra)
-+#device		uark		# Technologies ARK3116 based serial adapters
-+#device		ubsa		# Belkin F5U103 and compatible serial adapters
-+#device		uftdi		# For FTDI usb serial adapters
-+#device		uipaq		# Some WinCE based devices
-+#device		uplcom		# Prolific PL-2303 serial adapters
-+#device		uslcom		# SI Labs CP2101/CP2102 serial adapters
-+#device		uvisor		# Visor and Palm devices
-+#device		uvscom		# USB serial support for DDI pocket's PHS
-+# USB Ethernet, requires miibus
-+#device		aue		# ADMtek USB Ethernet
-+#device		axe		# ASIX Electronics USB Ethernet
-+#device		cdce		# Generic USB over Ethernet
-+#device		cue		# CATC USB Ethernet
-+#device		kue		# Kawasaki LSI USB Ethernet
-+#device		rue		# RealTek RTL8150 USB Ethernet
-+#device		udav		# Davicom DM9601E USB
-+# USB Wireless
-+#device		rum		# Ralink Technology RT2501USB wireless NICs
-+#device		run		# Ralink Technology RT2700/RT2800/RT3000 NICs.
-+#device		uath		# Atheros AR5523 wireless NICs
-+#device		upgt		# Conexant/Intersil PrismGT wireless NICs.
-+#device		ural		# Ralink Technology RT2500USB wireless NICs
-+#device		urtw		# Realtek RTL8187B/L wireless NICs
-+#device		zyd		# ZyDAS zd1211/zd1211b wireless NICs
-+
-+# FireWire support
-+#device		firewire	# FireWire bus code
-+# sbp(4) works for some systems but causes boot failure on others
-+#device		sbp		# SCSI over FireWire (Requires scbus and da)
-+#device		fwe		# Ethernet over FireWire (non-standard!)
-+#device		fwip		# IP over FireWire (RFC 2734,3146)
-+#device		dcons		# Dumb console driver
-+#device		dcons_crom	# Configuration ROM for dcons
-+
-+# Sound support
-+#device		sound		# Generic sound driver (required)
-+#device		snd_es137x	# Ensoniq AudioPCI ES137x
-+#device		snd_hda		# Intel High Definition Audio
-+#device		snd_ich		# Intel, NVidia and other ICH AC'97 Audio
-+#device		snd_uaudio	# USB Audio
-+#device		snd_via8233	# VIA VT8233x Audio
-diff --git a/sys/amd64/conf/SVAMAC b/sys/amd64/conf/SVAMAC
-new file mode 100644
-index 00000000..a20e7e5b
---- /dev/null
-+++ b/sys/amd64/conf/SVAMAC
-@@ -0,0 +1,342 @@
-+#
-+# GENERIC -- Generic kernel configuration file for FreeBSD/amd64
-+#
-+# For more information on this file, please read the config(5) manual page,
-+# and/or the handbook section on Kernel Configuration Files:
-+#
-+#    http://www.FreeBSD.org/doc/en_US.ISO8859-1/books/handbook/kernelconfig-config.html
-+#
-+# The handbook is also available locally in /usr/share/doc/handbook
-+# if you've installed the doc distribution, otherwise always see the
-+# FreeBSD World Wide Web server (http://www.FreeBSD.org/) for the
-+# latest information.
-+#
-+# An exhaustive list of options and more detailed explanations of the
-+# device lines is also present in the ../../conf/NOTES and NOTES files.
-+# If you are in doubt as to the purpose or necessity of a line, check first
-+# in NOTES.
-+#
-+# $FreeBSD: release/9.0.0/sys/amd64/conf/GENERIC 227305 2011-11-07 13:40:54Z marius $
-+
-+cpu		HAMMER
-+ident		SVAMAC
-+
-+makeoptions	DEBUG=-g		# Build kernel with gdb(1) debug symbols
-+
-+#options 	SCHED_ULE		# ULE scheduler
-+options   SCHED_4BSD
-+options 	PREEMPTION		# Enable kernel thread preemption
-+options 	INET			# InterNETworking
-+options 	INET6			# IPv6 communications protocols
-+options 	SCTP			# Stream Control Transmission Protocol
-+options 	FFS			# Berkeley Fast Filesystem
-+options 	SOFTUPDATES		# Enable FFS soft updates support
-+options 	UFS_ACL			# Support for access control lists
-+options 	UFS_DIRHASH		# Improve performance on big directories
-+options 	UFS_GJOURNAL		# Enable gjournal-based UFS journaling
-+options 	MD_ROOT			# MD is a potential root device
-+options 	NFSCL			# New Network Filesystem Client
-+options 	NFSD			# New Network Filesystem Server
-+options 	NFSLOCKD		# Network Lock Manager
-+options 	NFS_ROOT		# NFS usable as /, requires NFSCL
-+options 	MSDOSFS			# MSDOS Filesystem
-+options 	CD9660			# ISO 9660 Filesystem
-+options 	PROCFS			# Process filesystem (requires PSEUDOFS)
-+options 	PSEUDOFS		# Pseudo-filesystem framework
-+options 	GEOM_PART_GPT		# GUID Partition Tables.
-+options 	GEOM_LABEL		# Provides labelization
-+options 	COMPAT_FREEBSD32	# Compatible with i386 binaries
-+options 	COMPAT_FREEBSD4		# Compatible with FreeBSD4
-+options 	COMPAT_FREEBSD5		# Compatible with FreeBSD5
-+options 	COMPAT_FREEBSD6		# Compatible with FreeBSD6
-+options 	COMPAT_FREEBSD7		# Compatible with FreeBSD7
-+options 	SCSI_DELAY=5000		# Delay (in ms) before probing SCSI
-+options 	KTRACE			# ktrace(1) support
-+options 	STACK			# stack(9) support
-+options 	SYSVSHM			# SYSV-style shared memory
-+options 	SYSVMSG			# SYSV-style message queues
-+options 	SYSVSEM			# SYSV-style semaphores
-+options 	_KPOSIX_PRIORITY_SCHEDULING # POSIX P1003_1B real-time extensions
-+options 	PRINTF_BUFR_SIZE=128	# Prevent printf output being interspersed.
-+options 	KBD_INSTALL_CDEV	# install a CDEV entry in /dev
-+options 	HWPMC_HOOKS		# Necessary kernel hooks for hwpmc(4)
-+options 	AUDIT			# Security event auditing
-+options 	MAC			# TrustedBSD MAC Framework
-+#options 	KDTRACE_FRAME		# Ensure frames are compiled in
-+#options 	KDTRACE_HOOKS		# Kernel DTrace hooks
-+options 	INCLUDE_CONFIG_FILE     # Include this file in kernel
-+options 	KDB			# Kernel debugger related code
-+options 	KDB_TRACE		# Print a stack trace for a panic
-+options		DDB
-+options		BREAK_TO_DEBUGGER # Break signal on console goes into debugger
-+options		ALT_BREAK_TO_DEBUGGER # Break signal on console goes into debugger
-+
-+# Make an SMP-capable kernel by default
-+#options 	SMP			# Symmetric MultiProcessor Kernel
-+
-+# CPU frequency control
-+device		cpufreq
-+
-+# Bus support.
-+device		acpi
-+device		pci
-+
-+# Floppy drives
-+device		fdc
-+
-+# ATA controllers
-+device		ahci		# AHCI-compatible SATA controllers
-+device		ata		# Legacy ATA/SATA controllers
-+options 	ATA_CAM		# Handle legacy controllers with CAM
-+options 	ATA_STATIC_ID	# Static device numbering
-+device		mvs		# Marvell 88SX50XX/88SX60XX/88SX70XX/SoC SATA
-+device		siis		# SiliconImage SiI3124/SiI3132/SiI3531 SATA
-+
-+# SCSI Controllers
-+device		ahc		# AHA2940 and onboard AIC7xxx devices
-+options 	AHC_REG_PRETTY_PRINT	# Print register bitfields in debug
-+					# output.  Adds ~128k to driver.
-+device		ahd		# AHA39320/29320 and onboard AIC79xx devices
-+options 	AHD_REG_PRETTY_PRINT	# Print register bitfields in debug
-+					# output.  Adds ~215k to driver.
-+device		esp		# AMD Am53C974 (Tekram DC-390(T))
-+device		hptiop		# Highpoint RocketRaid 3xxx series
-+device		isp		# Qlogic family
-+#device		ispfw		# Firmware for QLogic HBAs- normally a module
-+device		mpt		# LSI-Logic MPT-Fusion
-+device		mps		# LSI-Logic MPT-Fusion 2
-+#device		ncr		# NCR/Symbios Logic
-+device		sym		# NCR/Symbios Logic (newer chipsets + those of `ncr')
-+device		trm		# Tekram DC395U/UW/F DC315U adapters
-+
-+device		adv		# Advansys SCSI adapters
-+device		adw		# Advansys wide SCSI adapters
-+device		aic		# Adaptec 15[012]x SCSI adapters, AIC-6[23]60.
-+device		bt		# Buslogic/Mylex MultiMaster SCSI adapters
-+
-+# ATA/SCSI peripherals
-+device		scbus		# SCSI bus (required for ATA/SCSI)
-+device		ch		# SCSI media changers
-+device		da		# Direct Access (disks)
-+device		sa		# Sequential Access (tape etc)
-+device		cd		# CD
-+device		pass		# Passthrough device (direct ATA/SCSI access)
-+device		ses		# SCSI Environmental Services (and SAF-TE)
-+
-+# RAID controllers interfaced to the SCSI subsystem
-+device		amr		# AMI MegaRAID
-+device		arcmsr		# Areca SATA II RAID
-+#XXX it is not 64-bit clean, -scottl
-+#device		asr		# DPT SmartRAID V, VI and Adaptec SCSI RAID
-+device		ciss		# Compaq Smart RAID 5*
-+device		dpt		# DPT Smartcache III, IV - See NOTES for options
-+device		hptmv		# Highpoint RocketRAID 182x
-+device		hptrr		# Highpoint RocketRAID 17xx, 22xx, 23xx, 25xx
-+device		iir		# Intel Integrated RAID
-+device		ips		# IBM (Adaptec) ServeRAID
-+device		mly		# Mylex AcceleRAID/eXtremeRAID
-+device		twa		# 3ware 9000 series PATA/SATA RAID
-+
-+# RAID controllers
-+device		aac		# Adaptec FSA RAID
-+device		aacp		# SCSI passthrough for aac (requires CAM)
-+device		ida		# Compaq Smart RAID
-+device		mfi		# LSI MegaRAID SAS
-+device		mlx		# Mylex DAC960 family
-+#XXX pointer/int warnings
-+#device		pst		# Promise Supertrak SX6000
-+device		twe		# 3ware ATA RAID
-+device		tws		# LSI 3ware 9750 SATA+SAS 6Gb/s RAID controller
-+
-+# atkbdc0 controls both the keyboard and the PS/2 mouse
-+device		atkbdc		# AT keyboard controller
-+device		atkbd		# AT keyboard
-+device		psm		# PS/2 mouse
-+
-+device		kbdmux		# keyboard multiplexer
-+
-+device		vga		# VGA video card driver
-+
-+device		splash		# Splash screen and screen saver support
-+
-+# syscons is the default console driver, resembling an SCO console
-+device		sc
-+options 	SC_PIXEL_MODE	# add support for the raster text mode
-+
-+device		agp		# support several AGP chipsets
-+
-+# PCCARD (PCMCIA) support
-+# PCMCIA and cardbus bridge support
-+device		cbb		# cardbus (yenta) bridge
-+device		pccard		# PC Card (16-bit) bus
-+device		cardbus		# CardBus (32-bit) bus
-+
-+# Serial (COM) ports
-+device		uart		# Generic UART driver
-+
-+# Parallel port
-+device		ppc
-+device		ppbus		# Parallel port bus (required)
-+device		lpt		# Printer
-+device		plip		# TCP/IP over parallel
-+device		ppi		# Parallel port interface device
-+#device		vpo		# Requires scbus and da
-+
-+device		puc		# Multi I/O cards and multi-channel UARTs
-+
-+# PCI Ethernet NICs.
-+device		bxe		# Broadcom BCM57710/BCM57711/BCM57711E 10Gb Ethernet
-+device		de		# DEC/Intel DC21x4x (``Tulip'')
-+device		em		# Intel PRO/1000 Gigabit Ethernet Family
-+device		igb		# Intel PRO/1000 PCIE Server Gigabit Family
-+device		ixgbe		# Intel PRO/10GbE PCIE Ethernet Family
-+device		le		# AMD Am7900 LANCE and Am79C9xx PCnet
-+device		ti		# Alteon Networks Tigon I/II gigabit Ethernet
-+device		txp		# 3Com 3cR990 (``Typhoon'')
-+device		vx		# 3Com 3c590, 3c595 (``Vortex'')
-+
-+# PCI Ethernet NICs that use the common MII bus controller code.
-+# NOTE: Be sure to keep the 'device miibus' line in order to use these NICs!
-+device		miibus		# MII bus support
-+device		ae		# Attansic/Atheros L2 FastEthernet
-+device		age		# Attansic/Atheros L1 Gigabit Ethernet
-+device		alc		# Atheros AR8131/AR8132 Ethernet
-+device		ale		# Atheros AR8121/AR8113/AR8114 Ethernet
-+device		bce		# Broadcom BCM5706/BCM5708 Gigabit Ethernet
-+device		bfe		# Broadcom BCM440x 10/100 Ethernet
-+device		bge		# Broadcom BCM570xx Gigabit Ethernet
-+device		dc		# DEC/Intel 21143 and various workalikes
-+device		et		# Agere ET1310 10/100/Gigabit Ethernet
-+device		fxp		# Intel EtherExpress PRO/100B (82557, 82558)
-+device		jme		# JMicron JMC250 Gigabit/JMC260 Fast Ethernet
-+device		lge		# Level 1 LXT1001 gigabit Ethernet
-+device		msk		# Marvell/SysKonnect Yukon II Gigabit Ethernet
-+device		nfe		# nVidia nForce MCP on-board Ethernet
-+device		nge		# NatSemi DP83820 gigabit Ethernet
-+#device		nve		# nVidia nForce MCP on-board Ethernet Networking
-+device		pcn		# AMD Am79C97x PCI 10/100 (precedence over 'le')
-+device		re		# RealTek 8139C+/8169/8169S/8110S
-+device		rl		# RealTek 8129/8139
-+device		sf		# Adaptec AIC-6915 (``Starfire'')
-+device		sge		# Silicon Integrated Systems SiS190/191
-+device		sis		# Silicon Integrated Systems SiS 900/SiS 7016
-+device		sk		# SysKonnect SK-984x & SK-982x gigabit Ethernet
-+device		ste		# Sundance ST201 (D-Link DFE-550TX)
-+device		stge		# Sundance/Tamarack TC9021 gigabit Ethernet
-+device		tl		# Texas Instruments ThunderLAN
-+device		tx		# SMC EtherPower II (83c170 ``EPIC'')
-+device		vge		# VIA VT612x gigabit Ethernet
-+device		vr		# VIA Rhine, Rhine II
-+device		wb		# Winbond W89C840F
-+device		xl		# 3Com 3c90x (``Boomerang'', ``Cyclone'')
-+
-+# ISA Ethernet NICs.  pccard NICs included.
-+device		cs		# Crystal Semiconductor CS89x0 NIC
-+# 'device ed' requires 'device miibus'
-+device		ed		# NE[12]000, SMC Ultra, 3c503, DS8390 cards
-+device		ex		# Intel EtherExpress Pro/10 and Pro/10+
-+device		ep		# Etherlink III based cards
-+device		fe		# Fujitsu MB8696x based cards
-+device		sn		# SMC's 9000 series of Ethernet chips
-+device		xe		# Xircom pccard Ethernet
-+
-+# Wireless NIC cards
-+device		wlan		# 802.11 support
-+options 	IEEE80211_DEBUG	# enable debug msgs
-+options 	IEEE80211_AMPDU_AGE # age frames in AMPDU reorder q's
-+options 	IEEE80211_SUPPORT_MESH	# enable 802.11s draft support
-+device		wlan_wep	# 802.11 WEP support
-+device		wlan_ccmp	# 802.11 CCMP support
-+device		wlan_tkip	# 802.11 TKIP support
-+device		wlan_amrr	# AMRR transmit rate control algorithm
-+device		an		# Aironet 4500/4800 802.11 wireless NICs.
-+device		ath		# Atheros NIC's
-+device		ath_pci		# Atheros pci/cardbus glue
-+device		ath_hal		# pci/cardbus chip support
-+options 	AH_SUPPORT_AR5416	# enable AR5416 tx/rx descriptors
-+device		ath_rate_sample	# SampleRate tx rate control for ath
-+#device		bwi		# Broadcom BCM430x/BCM431x wireless NICs.
-+#device		bwn		# Broadcom BCM43xx wireless NICs.
-+device		ipw		# Intel 2100 wireless NICs.
-+device		iwi		# Intel 2200BG/2225BG/2915ABG wireless NICs.
-+device		iwn		# Intel 4965/1000/5000/6000 wireless NICs.
-+device		malo		# Marvell Libertas wireless NICs.
-+device		mwl		# Marvell 88W8363 802.11n wireless NICs.
-+device		ral		# Ralink Technology RT2500 wireless NICs.
-+device		wi		# WaveLAN/Intersil/Symbol 802.11 wireless NICs.
-+device		wpi		# Intel 3945ABG wireless NICs.
-+
-+# Pseudo devices.
-+device		loop		# Network loopback
-+device		random		# Entropy device
-+device		ether		# Ethernet support
-+device		vlan		# 802.1Q VLAN support
-+device		tun		# Packet tunnel.
-+device		pty		# BSD-style compatibility pseudo ttys
-+device		md		# Memory "disks"
-+device		gif		# IPv6 and IPv4 tunneling
-+device		faith		# IPv6-to-IPv4 relaying (translation)
-+device		firmware	# firmware assist module
-+
-+# The `bpf' device enables the Berkeley Packet Filter.
-+# Be aware of the administrative consequences of enabling this!
-+# Note that 'bpf' is required for DHCP.
-+device		bpf		# Berkeley packet filter
-+
-+# USB support
-+options 	USB_DEBUG	# enable debug msgs
-+device		uhci		# UHCI PCI->USB interface
-+device		ohci		# OHCI PCI->USB interface
-+device		ehci		# EHCI PCI->USB interface (USB 2.0)
-+device		xhci		# XHCI PCI->USB interface (USB 3.0)
-+device		usb		# USB Bus (required)
-+#device		udbp		# USB Double Bulk Pipe devices (needs netgraph)
-+device		uhid		# "Human Interface Devices"
-+device		ukbd		# Keyboard
-+device		ulpt		# Printer
-+device		umass		# Disks/Mass storage - Requires scbus and da
-+device		ums		# Mouse
-+device		urio		# Diamond Rio 500 MP3 player
-+# USB Serial devices
-+device		u3g		# USB-based 3G modems (Option, Huawei, Sierra)
-+device		uark		# Technologies ARK3116 based serial adapters
-+device		ubsa		# Belkin F5U103 and compatible serial adapters
-+device		uftdi		# For FTDI usb serial adapters
-+device		uipaq		# Some WinCE based devices
-+device		uplcom		# Prolific PL-2303 serial adapters
-+device		uslcom		# SI Labs CP2101/CP2102 serial adapters
-+device		uvisor		# Visor and Palm devices
-+device		uvscom		# USB serial support for DDI pocket's PHS
-+# USB Ethernet, requires miibus
-+device		aue		# ADMtek USB Ethernet
-+device		axe		# ASIX Electronics USB Ethernet
-+device		cdce		# Generic USB over Ethernet
-+device		cue		# CATC USB Ethernet
-+device		kue		# Kawasaki LSI USB Ethernet
-+device		rue		# RealTek RTL8150 USB Ethernet
-+device		udav		# Davicom DM9601E USB
-+# USB Wireless
-+device		rum		# Ralink Technology RT2501USB wireless NICs
-+device		run		# Ralink Technology RT2700/RT2800/RT3000 NICs.
-+device		uath		# Atheros AR5523 wireless NICs
-+device		upgt		# Conexant/Intersil PrismGT wireless NICs.
-+device		ural		# Ralink Technology RT2500USB wireless NICs
-+device		urtw		# Realtek RTL8187B/L wireless NICs
-+device		zyd		# ZyDAS zd1211/zd1211b wireless NICs
-+
-+# FireWire support
-+device		firewire	# FireWire bus code
-+# sbp(4) works for some systems but causes boot failure on others
-+#device		sbp		# SCSI over FireWire (Requires scbus and da)
-+device		fwe		# Ethernet over FireWire (non-standard!)
-+device		fwip		# IP over FireWire (RFC 2734,3146)
-+device		dcons		# Dumb console driver
-+device		dcons_crom	# Configuration ROM for dcons
-+
-+# Sound support
-+device		sound		# Generic sound driver (required)
-+device		snd_es137x	# Ensoniq AudioPCI ES137x
-+device		snd_hda		# Intel High Definition Audio
-+device		snd_ich		# Intel, NVidia and other ICH AC'97 Audio
-+device		snd_uaudio	# USB Audio
-+device		snd_via8233	# VIA VT8233x Audio
 diff --git a/sys/amd64/ia32/ia32_syscall.c b/sys/amd64/ia32/ia32_syscall.c
 index 0e27f04b..1a46058a 100644
 --- a/sys/amd64/ia32/ia32_syscall.c
@@ -5917,159 +5316,6 @@ index 1578a66b..66ba8bba 100644
  
  	newtd->td_pflags |= TDP_KTHREAD;
  	newtd->td_ucred = crhold(p->p_ucred);
-diff --git a/sys/kern/kern_sva.c b/sys/kern/kern_sva.c
-new file mode 100644
-index 00000000..05b63a53
---- /dev/null
-+++ b/sys/kern/kern_sva.c
-@@ -0,0 +1,147 @@
-+/*===- kern_sva.c - SVA Kernel Callbacks =-----------------------------------===
-+ * 
-+ *                        Secure Virtual Architecture
-+ *
-+ * This file was developed by the LLVM research group and is distributed under
-+ * the University of Illinois Open Source License. See LICENSE.TXT for details.
-+ * 
-+ *===----------------------------------------------------------------------===
-+ *
-+ * This file implements functions that the kernel needs to provide to SVA.
-+ *
-+ *===----------------------------------------------------------------------===
-+ */
-+
-+#include <sys/malloc.h>
-+#include <sys/types.h>
-+#include <sys/proc.h>
-+
-+#include <sys/cdefs.h>
-+#include <vm/vm.h>
-+#include <vm/vm_param.h>
-+#include <vm/vm_kern.h>
-+#include <vm/vm_page.h>
-+#include <vm/vm_map.h>
-+#include <vm/vm_object.h>
-+#include <vm/vm_extern.h>
-+#include <vm/vm_pageout.h>
-+#include <vm/vm_reserv.h>
-+#include <vm/pmap.h>
-+#include <vm/uma.h>
-+
-+#include <sys/pcpu.h>
-+#include <machine/frame.h>
-+
-+/* Function prototypes */
-+uintptr_t provideSVAMemory (uintptr_t size);
-+void releaseSVAMemory (uintptr_t p, uintptr_t size);
-+
-+/*
-+ * Function: provideSVAMemory()
-+ *
-+ * Description:
-+ *  Allocate memory and pass it to SVA to use.
-+ *
-+ * Inputs:
-+ *  The amount of memory to give SVA in bytes.
-+ *
-+ * Return value:
-+ *  The first physical address of the memory that SVA can use.
-+ */
-+uintptr_t
-+provideSVAMemory (uintptr_t size)
-+{
-+  /* Structure to get a page */
-+  vm_page_t bufferPage;
-+
-+  /* Virtual address of memory to be returned. */
-+  unsigned char * p;
-+
-+  /*
-+   * Check to see if a single page will do.  If not, then panic.
-+   */
-+  if (size > 4096u)
-+    panic ("SVA: providesSVAMemory: Too much memory requested: %ld\n", size);
-+
-+  /*
-+   * Request a page from the page manager.
-+   */
-+	bufferPage = vm_page_alloc (NULL, 0, VM_ALLOC_NORMAL | VM_ALLOC_NOOBJ);
-+
-+  /*
-+   * Unmap the page from the 1 TB direct map.
-+   */
-+	p = (void *) PHYS_TO_DMAP(VM_PAGE_TO_PHYS(bufferPage));
-+  pmap_remove (&(curproc->p_vmspace->vm_pmap),
-+               (vm_offset_t) p,
-+               (vm_offset_t) p + 4096);
-+
-+  /*
-+   * Convert the page into a physical address and return it.
-+   */
-+	return VM_PAGE_TO_PHYS(bufferPage);
-+}
-+
-+/*
-+ * Function: releaseSVAMemory()
-+ *
-+ * Description:
-+ *  SVA calls this function when it no longer needs a piece of memory.
-+ *
-+ * Inputs:
-+ *  paddr - The first physical address of the memory to release back to the OS.
-+ *  size  - The length of the memory in bytes to release.
-+ *
-+ */
-+void
-+releaseSVAMemory (uintptr_t paddr, uintptr_t size)
-+{
-+  /* Paging structure for the memory */
-+  vm_page_t page;
-+
-+  /*
-+   * Convert the physical address into a vm_page_t.
-+   */
-+  page = vm_phys_paddr_to_vm_page (paddr);
-+
-+  /*
-+   * Figure out where in the virtual address space it should go.
-+   */
-+	unsigned char * p = (void *) PHYS_TO_DMAP(VM_PAGE_TO_PHYS(page));
-+
-+  /*
-+   * Remap the page back into the direct 1 TB map.
-+   */
-+  pmap_enter (&(curproc->p_vmspace->vm_pmap),
-+               (vm_offset_t) p,
-+               0,
-+               page,
-+               VM_PROT_READ | VM_PROT_WRITE,
-+               0);
-+
-+  /*
-+   * Now free the page.
-+   */
-+  vm_page_free (page);
-+  return;
-+}
-+
-+/*
-+ * Function: testSVAMemory()
-+ *
-+ * Description:
-+ *  Try to access secure memory.
-+ */
-+void
-+testSVAMemory (unsigned char * p) {
-+  /*
-+   * Testing time: Attempt to access the secure memory.
-+   */
-+  printf ("Kernel: Spying on you!  Secret is: \n");
-+  for (int index = 0; index < 5; ++index) {
-+    printf ("%c", p[index]);
-+  }
-+  printf ("\n");
-+  return;
-+}
-+
 diff --git a/sys/kern/sched_4bsd.c b/sys/kern/sched_4bsd.c
 index 06d55cd1..ba6f7bfd 100644
 --- a/sys/kern/sched_4bsd.c


### PR DESCRIPTION
Enable FS/FSBASE and related kernel structure save/restore during context switching (cpu_switch_sva) and system call handling (sva_syscall), as well as other places operating those structures or registers.

A clearer patch for kernel can be viewed online: https://github.com/tupipa/sva_freebsd90/commit/09a82b2636bd453664e200a85eeda27d27e53d72

Known issues:

- [Solved 12/11/2018] only support single user mode. Multi-user mode would boot but some applications (such as `cat`) would crash with 'Segmentation fault' and root will be forced out immediately after logging in. 

- multi-threading library (pthread) not supported. Applications creating new thread will get error: "SVA: Error!  Kernel performing unauthorized fork()!"

