### PR TITLE
Add TLS support to SVA. TLS segmentation is managed in SVA.

### DIFF
--- a/SVA/include/sva/state.h
+++ b/SVA/include/sva/state.h
@@ -23,6 +23,8 @@
 #include "sva/keys.h"
 
 
+#define SVA_FS_SEL 0x13
+
 extern void usersva_to_kernel_pcid(void);
 extern void kernel_to_usersva_pcid(void);
 
@@ -223,6 +225,17 @@ typedef struct {
 
   /* Pointer to invoke frame */
   struct invoke_frame * ifp;
+
+  /* FS segment base address, for TLS support in SVA
+   * as a replacement of pcb_fsbase in kernel amd64/include/pcb.h 
+   */
+  uint64_t fsbase;
+
+  /* PCB flags,  to replace pcb_flags ( PCB_FULL_IRET,etc.) in kernel amd64/include/pcb.h */
+  uint32_t state_flags;
+
+#define	STATE_FULL_IRET	0x01	/* indicating a iret with restore of FSBASE and other segmentations (yet to implement) to MSR */
+  
 } sva_integer_state_t;
 
 /* The maximum number of interrupt contexts per CPU */
@@ -425,6 +438,8 @@ extern uintptr_t sva_init_stack (unsigned char * sp,
 extern void sva_reinit_icontext (void *, unsigned char, uintptr_t, uintptr_t);
 
 extern void sva_release_stack (uintptr_t id);
+
+extern void sva_init_fsbase(uintptr_t svaID, uint64_t base);
 
 /*****************************************************************************
  * Individual State Components

--- a/SVA/lib/handlers.S
+++ b/SVA/lib/handlers.S
@@ -576,10 +576,10 @@ L14:
   /*
    * Copy the registers from the interrupt context back on to the processor.
    */
-  movw IC_FS(%rsp), %ax
+  /* movw IC_FS(%rsp), %ax */ 
   movw IC_ES(%rsp), %bx
   movw IC_DS(%rsp), %cx
-  movw %ax, %fs
+  /* movw %ax, %fs */ /* handled below instead, for TLS support in AMD64*/
   movw %bx, %es
   movw %cx, %ds
 
@@ -798,6 +798,13 @@ L22:
   /* Push a NULL invoke pointer into the Interrupt Context */
   pushq $0
 
+  /*
+   * clear IRET flag:  If returned from syscall with no context switch,
+   * Then we do not need to restore FSBASE MSR
+   */
+  movq %gs:0x260, %rbp
+  movq CPU_THREAD(%rbp), %rax
+  andl $~STATE_FULL_IRET, TD_INTSTATE+IS_STATE_FLAGS(%rax)
 
   /*
    * Mark the interrupt context as valid.  Additionally, set the fork bit
@@ -1018,12 +1025,18 @@ L18:
  /*
    * Copy the registers from the interrupt context back on to the processor.
    */
-  movw IC_FS(%rsp), %cx
+  /* movw IC_FS(%rsp), %cx */
   movw IC_ES(%rsp), %bx
   movw IC_DS(%rsp), %ax
-  movw %cx, %fs
+  /* movw %cx, %fs */ /* this will be done in full_iret instead */
   movw %bx, %es
   movw %ax, %ds
+
+  movq CPU_THREAD(%rbp), %rbx
+  testl	$STATE_FULL_IRET, TD_INTSTATE + IS_STATE_FLAGS(%rbx)
+	jnz	full_iret
+
+done_full_iret:
 
   movq IC_RDI(%rsp), %rdi
   movq IC_RSI(%rsp), %rsi
@@ -1088,6 +1101,37 @@ L23:
    */
   sysretq
 
+
+/* 
+ * full_iret: This is used to replace the kernel's function of restoring 
+ * FS/GS/DS/ES segmentations when PCB_FULL_IRET is set upon the syscall return.
+ * 
+ * Currently used to restore FSBASE only. GSBASE can also use this 
+ * routine if applications use different GS segments in the future. 
+ * This helps avoid overhead of restoring everytime upon sysret, 
+ * 
+ */
+full_iret:
+
+	/* Restore %fs and fsbase */
+  /* %rbx points to the thread structure which contains integer state structure
+   * %rsp points to the IC context to restore
+   */
+	movw	IC_FS(%rsp),%ax
+	movw	%ax,%fs
+
+  /* make sure fs is valid */ 
+	cmpw	$SVA_FS_SEL,%ax
+	jne	invalidIC /*lele: here fs in IC_FS should always be SVA_FS_SEL (0x13) */
+
+  /* write MSR for fsbase */
+	movl	$MSR_FSBASE,%ecx
+	movl	TD_INTSTATE + IS_FSBASE(%rbx),%eax
+	movl	TD_INTSTATE + IS_FSBASE + 4(%rbx),%edx
+	wrmsr
+
+  jmp done_full_iret
+ 
 /* Define the trap handlers */
 TRAP(0)
 TRAP(1)

--- a/SVA/lib/offsets.h
+++ b/SVA/lib/offsets.h
@@ -70,6 +70,18 @@
 #define TSS_RSP0 4
 #define TSS_IST3 52
 
+
+
+/* Offsets into the SVAThread and sva_integer_state_t structures */
+#define TD_INTSTATE    0x7a40 // __offsetof(struct SVAThread, integerState)
+#define IS_FSBASE      0x308 // __offsetof(sva_integer_state_t , fsbase)
+#define IS_STATE_FLAGS 0x310 // __offsetof(sva_integer_state_t , state_flags)
+
+#ifndef STATE_FULL_IRET
+#define	STATE_FULL_IRET	0x01
+#endif
+
+
 /* Types of Invoke Frames */
 #define INVOKE_NORMAL   0
 #define INVOKE_MEMCPY_W 1
@@ -78,3 +90,13 @@
 #define INVOKE_MEMSET   2
 
 
+
+/* segment registers for TLS support
+ * refer: sys/amd64/include/specialreg.h
+*/
+
+#ifndef SVA_FS_SEL
+#define SVA_FS_SEL 0x13
+#endif 
+
+#define	MSR_FSBASE	0xc0000100	/* base address of the %fs "segment" */

--- a/freebsd9_patch
+++ b/freebsd9_patch
@@ -1,5 +1,5 @@
 diff --git a/lib/libc/stdlib/malloc.c b/lib/libc/stdlib/malloc.c
-index fb634f80..31eed581 100644
+index fb634f80..3f1c58df 100644
 --- a/lib/libc/stdlib/malloc.c
 +++ b/lib/libc/stdlib/malloc.c
 @@ -155,7 +155,10 @@
@@ -90,7 +90,7 @@ index fb634f80..31eed581 100644
   */
 +
 +/* SVA: No TLS support for now */
-+#define NO_TLS
++// #define NO_TLS
 +
  #ifdef __i386__
  #  define LG_QUANTUM		4
@@ -674,7 +674,7 @@ index 0706fa61..e84c5ad0 100644
  	jmp	0b
  
 diff --git a/sys/amd64/amd64/machdep.c b/sys/amd64/amd64/machdep.c
-index 0890c1b0..52bcfb26 100644
+index 0890c1b0..1fb3486b 100644
 --- a/sys/amd64/amd64/machdep.c
 +++ b/sys/amd64/amd64/machdep.c
 @@ -55,6 +55,7 @@ __FBSDID("$FreeBSD: release/9.0.0/sys/amd64/amd64/machdep.c 225617 2011-09-16 13
@@ -1158,7 +1158,17 @@ index 0890c1b0..52bcfb26 100644
          env = getenv("kernelname");
  	if (env != NULL)
  		strlcpy(kernelname, env, sizeof(kernelname));
-@@ -2397,6 +2619,254 @@ user_dbreg_trap(void)
+@@ -2143,6 +2365,9 @@ set_mcontext(struct thread *td, const mcontext_t *mcp)
+ 		pcb->pcb_gsbase = mcp->mc_gsbase;
+ 	}
+ 	set_pcb_flags(pcb, PCB_FULL_IRET);
++
++	/* update fsbase in SVA */
++	sva_init_fsbase(td->svaID, pcb->pcb_fsbase); // never reached here yet.
+ 	return (0);
+ }
+ 
+@@ -2397,6 +2622,259 @@ user_dbreg_trap(void)
          return 0;
  }
  
@@ -1259,7 +1269,10 @@ index 0890c1b0..52bcfb26 100644
 +     * Update the FreeBSD per-cpu data structure to know which thread is
 +     * running on this CPU.
 +     */
++
++    PCPU_SET(curpcb, new->td_pcb);
 +    PCPU_SET (curthread, new);
++
 +
 +    /*
 +     * Swap to the new state.
@@ -1384,6 +1397,8 @@ index 0890c1b0..52bcfb26 100644
 +     * Update the FreeBSD per-cpu data structure to know which thread is
 +     * running on this CPU.
 +     */
++
++    PCPU_SET(curpcb, new->td_pcb);
 +    PCPU_SET (curthread, new);
 +
 +    /*
@@ -3624,10 +3639,25 @@ index 00000000..ed8ff1dc
 +  }
 +}
 diff --git a/sys/amd64/amd64/sys_machdep.c b/sys/amd64/amd64/sys_machdep.c
-index 743a1200..519f6ec5 100644
+index 743a1200..78428beb 100644
 --- a/sys/amd64/amd64/sys_machdep.c
 +++ b/sys/amd64/amd64/sys_machdep.c
-@@ -318,6 +318,8 @@ amd64_set_ioperm(td, uap)
+@@ -271,6 +271,14 @@ sysarch(td, uap)
+ 				pcb->pcb_fsbase = a64base;
+ 				set_pcb_flags(pcb, PCB_FULL_IRET);
+ 				td->td_frame->tf_fs = _ufssel;
++
++				/* Setup fsbase in SVA. This is a hack since we should allow SVA
++				 * to control the initialization of FS segmentation (for TLS support).
++				 * For example, a better solution could be allow application/libc to 
++				 * invoke a hypercall to setup its fsbase.
++				 */
++				sva_init_fsbase(td->svaID, a64base);
++
+ 			} else
+ 				error = EINVAL;
+ 		}
+@@ -318,6 +326,8 @@ amd64_set_ioperm(td, uap)
  	if (uap->start + uap->length > IOPAGES * PAGE_SIZE * NBBY)
  		return (EINVAL);
  
@@ -4585,7 +4615,7 @@ index f3db837e..af0769c3 100644
  }
 +#endif
 diff --git a/sys/amd64/amd64/vm_machdep.c b/sys/amd64/amd64/vm_machdep.c
-index c0be7202..10107ff7 100644
+index c0be7202..8ded2e4f 100644
 --- a/sys/amd64/amd64/vm_machdep.c
 +++ b/sys/amd64/amd64/vm_machdep.c
 @@ -83,6 +83,10 @@ __FBSDID("$FreeBSD: release/9.0.0/sys/amd64/amd64/vm_machdep.c 223758 2011-07-04
@@ -4622,7 +4652,7 @@ index c0be7202..10107ff7 100644
  /*
   * Finish a fork operation, with process p2 nearly set up.
   * Copy and update the pcb, set up the stack so that the child
-@@ -216,6 +236,27 @@ cpu_fork(td1, p2, td2, flags)
+@@ -216,6 +236,33 @@ cpu_fork(td1, p2, td2, flags)
  		mdp2->md_ldt = NULL;
  	mtx_unlock(&dt_lock);
  
@@ -4646,11 +4676,17 @@ index c0be7202..10107ff7 100644
 +	                             td2,
 +	                             0,
 +                               0);
++
++  /* Update fsbase in SVA -- TLS support */
++  if (pcb2->pcb_fsbase != 0){
++	sva_init_fsbase(td2->svaID, pcb2->pcb_fsbase);
++  }
++
 +#endif
  	/*
  	 * Now, cpu_switch() can schedule the new process.
  	 * pcb_rsp is loaded pointing to the cpu_switch() stack frame
-@@ -245,6 +286,10 @@ cpu_set_fork_handler(td, func, arg)
+@@ -245,6 +292,10 @@ cpu_set_fork_handler(td, func, arg)
  	 */
  	td->td_pcb->pcb_r12 = (long) func;	/* function */
  	td->td_pcb->pcb_rbx = (long) arg;	/* first arg */
@@ -4661,7 +4697,7 @@ index c0be7202..10107ff7 100644
  }
  
  void
-@@ -259,6 +304,13 @@ cpu_exit(struct thread *td)
+@@ -259,6 +310,13 @@ cpu_exit(struct thread *td)
  		user_ldt_free(td);
  	else
  		mtx_unlock(&dt_lock);
@@ -4675,7 +4711,7 @@ index c0be7202..10107ff7 100644
  }
  
  void
-@@ -327,12 +379,15 @@ cpu_thread_free(struct thread *td)
+@@ -327,12 +385,15 @@ cpu_thread_free(struct thread *td)
  void
  cpu_set_syscall_retval(struct thread *td, int error)
  {
@@ -4692,7 +4728,7 @@ index c0be7202..10107ff7 100644
  		break;
  
  	case ERESTART:
-@@ -345,8 +400,13 @@ cpu_set_syscall_retval(struct thread *td, int error)
+@@ -345,8 +406,13 @@ cpu_set_syscall_retval(struct thread *td, int error)
  		 * %r10 restore is only required for freebsd/amd64 processes,
  		 * but shall be innocent for any ia32 ABI.
  		 */
@@ -4706,7 +4742,7 @@ index c0be7202..10107ff7 100644
  		break;
  
  	case EJUSTRETURN:
-@@ -359,8 +419,12 @@ cpu_set_syscall_retval(struct thread *td, int error)
+@@ -359,8 +425,12 @@ cpu_set_syscall_retval(struct thread *td, int error)
  			else
  				error = td->td_proc->p_sysent->sv_errtbl[error];
  		}
@@ -4719,7 +4755,7 @@ index c0be7202..10107ff7 100644
  		break;
  	}
  }
-@@ -424,7 +488,108 @@ cpu_set_upcall(struct thread *td, struct thread *td0)
+@@ -424,7 +494,120 @@ cpu_set_upcall(struct thread *td, struct thread *td0)
  	/* Setup to release spin count in fork_exit(). */
  	td->td_md.md_spinlock_count = 1;
  	td->td_md.md_saved_flags = PSL_KERNEL | PSL_I;
@@ -4739,6 +4775,12 @@ index c0be7202..10107ff7 100644
 +                              td,
 +                              0,
 +	                            0);
++
++  /* Update fsbase in SVA -- TLS support */
++  if (pcb2->pcb_fsbase != 0){
++	sva_init_fsbase(td->svaID, pcb2->pcb_fsbase);
++  }
++
 +#endif
 +}
 +
@@ -4821,6 +4863,12 @@ index c0be7202..10107ff7 100644
 +                              td,
 +                              0,
 +	                            0);
++
++  /* Update fsbase in SVA -- TLS support */
++  if (pcb2->pcb_fsbase != 0){
++	sva_init_fsbase(td->svaID, pcb2->pcb_fsbase);
++  }
++
 +#endif
  }
 +#endif
@@ -4828,6 +4876,21 @@ index c0be7202..10107ff7 100644
  
  /*
   * Set that machine state for performing an upcall that has to
+@@ -506,6 +689,14 @@ cpu_set_user_tls(struct thread *td, void *tls_base)
+ #endif
+ 	pcb->pcb_fsbase = (register_t)tls_base;
+ 	set_pcb_flags(pcb, PCB_FULL_IRET);
++
++	if (td->svaID){
++		sva_init_fsbase(td->svaID, tls_base); // never reached here yet.
++	}else{
++		panic("%s[%d:%d] has no svaID, cannot init fsbase for thread\n", 
++			td->td_proc->p_comm, td->td_proc->p_pid, td->td_tid);
++	}
++
+ 	return (0);
+ }
+ 
 diff --git a/sys/amd64/conf/SVA b/sys/amd64/conf/SVA
 new file mode 100644
 index 00000000..aeb23998


### PR DESCRIPTION
Enable FS/FSBASE and related SVA structure save/restore during system call dispatching (SVAsyscall in handler.S) and context switching (sva_swap_integer). Kernel is also patched (as a hack) for initialization (or reset) of FSBASE.

A clearer patch for kernel can be viewed online: https://github.com/tupipa/sva_freebsd90/commit/a1edb59cda3d30a61cb1d212e8fee80a166f8a2d

Known Issues:
  1. multi-threading library (pthread) not supported. Applications creating new thread will get error: "SVA: Error! Kernel performing unauthorized fork()!"
  2. When booting into multi-user mode, some user programs will crash with segmentation fault, such as dd, cat, sysctl, ps, etc. But the system will boot and run with TLS enabled applications.